### PR TITLE
Improve zoom and branding on inverse metrics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -679,7 +679,7 @@
   .custom-scroll::-webkit-scrollbar-track {
     background: #1e293b;
   }
-</style><script src="https://cdn.jsdelivr.net/npm/chart.js"></script><script src="https://cdn.jsdelivr.net/npm/chart.js"></script><script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</style>
 <style>
 #refreshWalletData, #chart-export-btn, #connectWallet {
     background-color: var(--primary-color) !important;
@@ -749,7 +749,7 @@
 <spline-viewer url="https://prod.spline.design/fJRTSatt5qGHtFUW/scene.splinecode"></spline-viewer>
 </div>
 <div class="particles" id="particles"></div>
-<div id="beta-banner">⚡ QuantumI Beta Pro Release</div>
+<div id="beta-banner">QuantumI Alpha Beta Pro Release</div>
 <header class="w-full flex justify-center items-center">
 <div class="w-full max-w-[98vw] mx-auto px-4">
 <div class="title-box">
@@ -933,7 +933,7 @@
 </section>
 <section class="rounded-lg" draggable="true" id="inverse-winners-module">
 <div class="module-header">
-<h2 class="text-lg md:text-xl typewriter">📊 Inverse Metrics</h2>
+<h2 class="text-lg md:text-xl typewriter">Inverse Metrics</h2>
 <button aria-label="Toggle module visibility" class="toggle-module-btn" data-tooltip="Toggle module visibility" role="button">▼</button>
 </div>
 <div class="module-content">
@@ -1154,7 +1154,7 @@
       }, 500);
     };
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const particle = document.createElement('div');
       particle.className = 'star';
       particle.style.left = `${Math.random() * 100}%`;
@@ -1163,7 +1163,7 @@
       DOM.particleContainer.appendChild(particle);
     }
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const snowflake = document.createElement('div');
       snowflake.className = 'snowflake';
       snowflake.textContent = '❄️';
@@ -2215,29 +2215,27 @@
         addSystemLog('Exported BTC Hash Visualization as OBJ');
       });
 
-      let zoomInterval;
-      function startZoom(dir) {
-        let speed = 0.02;
-        clearInterval(zoomInterval);
-        zoomInterval = setInterval(() => {
-          if (camera) {
-            const factor = dir === 'in' ? 1 - speed : 1 + speed;
-            camera.position.multiplyScalar(factor);
-            controls.update();
-            speed = Math.min(speed * 1.05, 0.15);
-          }
-        }, 50);
+      let zoomDirection = 0;
+      let zoomSpeed = 0;
+      function zoomLoop() {
+        if (zoomDirection !== 0 && camera) {
+          zoomSpeed = Math.min(zoomSpeed + 0.0008, 0.04);
+          const factor = zoomDirection > 0 ? 1 - zoomSpeed : 1 + zoomSpeed;
+          camera.position.multiplyScalar(factor);
+          controls.update();
+        } else {
+          zoomSpeed = 0;
+        }
+        requestAnimationFrame(zoomLoop);
       }
-      function stopZoom() {
-        clearInterval(zoomInterval);
-      }
+      zoomLoop();
       ['mousedown','touchstart'].forEach(ev => {
-        DOM.zoomInBtn.addEventListener(ev, () => startZoom('in'));
-        DOM.zoomOutBtn.addEventListener(ev, () => startZoom('out'));
+        DOM.zoomInBtn.addEventListener(ev, () => { zoomDirection = 1; });
+        DOM.zoomOutBtn.addEventListener(ev, () => { zoomDirection = -1; });
       });
       ['mouseup','mouseleave','touchend'].forEach(ev => {
-        DOM.zoomInBtn.addEventListener(ev, stopZoom);
-        DOM.zoomOutBtn.addEventListener(ev, stopZoom);
+        DOM.zoomInBtn.addEventListener(ev, () => { zoomDirection = 0; });
+        DOM.zoomOutBtn.addEventListener(ev, () => { zoomDirection = 0; });
       });
 
       DOM.exportHashLogBtn.addEventListener('click', () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,6 +68,14 @@
       opacity: 0;
       transition: opacity 0.5s ease-in;
     }
+    #beta-banner {
+      background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
+      color: #000;
+      text-align: center;
+      padding: 0.25rem 0;
+      font-weight: bold;
+      font-size: 0.875rem;
+    }
     .spline-bg {
       position: fixed;
       top: 0;
@@ -674,11 +682,37 @@
 </style><script src="https://cdn.jsdelivr.net/npm/chart.js"></script><script src="https://cdn.jsdelivr.net/npm/chart.js"></script><script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <style>
 #refreshWalletData, #chart-export-btn, #connectWallet {
-    background-color: #2563EB !important; /* blue-600 */
+    background-color: var(--primary-color) !important;
+    color: #000 !important;
     transition: background-color 0.3s ease;
 }
 #refreshWalletData:hover, #chart-export-btn:hover, #connectWallet:hover {
-    background-color: #1D4ED8 !important; /* blue-700 */
+    background-color: #6fc8e9 !important;
+}
+.cmc-link {
+    color: var(--primary-color);
+    cursor: pointer;
+}
+.cmc-link:hover {
+    color: var(--secondary-color);
+    text-decoration: underline;
+}
+.text-brand-blue {
+    color: var(--primary-color);
+}
+.text-brand-orange {
+    color: var(--secondary-color);
+}
+.zoom-btn {
+    background-color: var(--primary-color);
+    color: #000;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.zoom-btn:hover {
+    background-color: #6fc8e9;
 }
 </style>
 </head>
@@ -715,6 +749,7 @@
 <spline-viewer url="https://prod.spline.design/fJRTSatt5qGHtFUW/scene.splinecode"></spline-viewer>
 </div>
 <div class="particles" id="particles"></div>
+<div id="beta-banner">⚡ QuantumI Beta Pro Release</div>
 <header class="w-full flex justify-center items-center">
 <div class="w-full max-w-[98vw] mx-auto px-4">
 <div class="title-box">
@@ -805,7 +840,7 @@
 <div class="module-content">
 <div class="loader text-center text-gray-500 text-sm" id="loader-tokens">&gt; Loading...</div>
 <div class="data-warning" id="token-warning" style="display: none;">&gt; Live data from Dune API</div>
-<ul class="space-y-2 text-sm" id="token-list" onclick="openCMC(event)"></ul>
+<ul class="space-y-2 text-sm" id="token-list"></ul>
 <div class="mt-4">
 <h3 class="text-base md:text-lg mb-2 typewriter">&gt; Performers</h3>
 <ul class="space-y-2 text-sm" id="profit-pairs"></ul>
@@ -926,7 +961,7 @@
 <option value="10">Top 10</option>
 <option value="20">Top 20</option>
 </select>
-<button class="ml-4 bg-blue-600 text-white px-3 py-1 rounded text-sm hover:bg-blue-700" onclick="exportChart()">📤 Export</button>
+        <button class="ml-4 text-white px-3 py-1 rounded text-sm" id="chart-export-btn" onclick="exportChart()">📤 Export</button>
 </div>
 </div>
 <canvas class="w-full max-w-3xl mx-auto h-72 md:h-96" id="inverseChart"></canvas>
@@ -935,7 +970,7 @@
 <section class="rounded-lg col-span-full" draggable="true" id="live-logs-module">
 <div class="module-header flex justify-between items-center">
 <h2 class="text-lg md:text-xl text-white">🔐 Wallet Log Module</h2>
-<button class="bg-blue-600 hover:bg-blue-700 text-white py-1 px-4 rounded text-sm" id="refreshWalletData">🔄 Refresh Wallet</button>
+<button class="text-white py-1 px-4 rounded text-sm" id="refreshWalletData">🔄 Refresh Wallet</button>
 </div>
 <div class="module-content text-white">
 <div class="wallet-info my-2">
@@ -965,6 +1000,10 @@
 <span id="btc-momentum">Momentum: Loading...</span>
 </div>
 <div class="mt-2 flex justify-center gap-2" id="btc-color-legend"></div>
+<div class="mt-2 flex justify-center gap-2" id="btc-zoom-controls">
+  <button class="zoom-btn" id="btc-zoom-in" aria-label="Zoom in">+</button>
+  <button class="zoom-btn" id="btc-zoom-out" aria-label="Zoom out">-</button>
+</div>
 <div class="mt-4 text-sm" id="btc-legend-explanation">
 <h3 class="text-base md:text-lg mb-2">Legend</h3>
 <p>Each particle cloud represents a snapshot of BTC price and volume data over the last 24 hours.</p>
@@ -1034,6 +1073,8 @@
       exportGasBtn: document.getElementById('export-gas'),
       tokenPerformanceChart: document.getElementById('token-performance-chart'),
       exportObjBtn: document.getElementById('export-obj'),
+      zoomInBtn: document.getElementById('btc-zoom-in'),
+      zoomOutBtn: document.getElementById('btc-zoom-out'),
       undockBackgroundLink: document.getElementById('undock-background-link'),
       exportHashLogBtn: document.getElementById('export-hash-log'),
       exportBalancesBtn: document.getElementById('export-balances'),
@@ -1875,10 +1916,11 @@
         const symbol = `BINANCE:${token.symbol}USDT`;
         return `
           <li class="${index === 0 ? 'selected-token' : ''}" data-symbol="${symbol}" data-tooltip="View ${token.symbol} chart">
-            <div class="flex justify-between">
+            <div class="flex justify-between items-center">
               <span>${token.name} (${token.symbol})</span>
               <span class="performance ${isPositive ? 'text-green-400' : 'text-orange-400'}">${token.price_change_percentage_24h >= 0 ? '+' : ''}${token.price_change_percentage_24h.toFixed(2)}%</span>
             </div>
+            <span class="cmc-link mt-1 text-xs" data-cmc="${token.id}" aria-label="Open CoinMarketCap page">CMC</span>
             <div class="metric">Price: $${token.current_price.toLocaleString()}</div>
             <div class="metric">Volume: ${token.total_volume.toLocaleString()} USD</div>
             <div class="metric">Supply: ${token.circulating_supply.toLocaleString()}</div>
@@ -2033,6 +2075,14 @@
       });
 
       DOM.tokenList.addEventListener('click', (e) => {
+        const cmcBtn = e.target.closest('.cmc-link');
+        if (cmcBtn) {
+          e.stopPropagation();
+          const cmc = cmcBtn.getAttribute('data-cmc');
+          window.open(`https://coinmarketcap.com/currencies/${cmc}/`, '_blank');
+          return;
+        }
+
         const li = e.target.closest('li');
         if (li && li.dataset.symbol) {
           const symbol = li.dataset.symbol;
@@ -2165,6 +2215,31 @@
         addSystemLog('Exported BTC Hash Visualization as OBJ');
       });
 
+      let zoomInterval;
+      function startZoom(dir) {
+        let speed = 0.02;
+        clearInterval(zoomInterval);
+        zoomInterval = setInterval(() => {
+          if (camera) {
+            const factor = dir === 'in' ? 1 - speed : 1 + speed;
+            camera.position.multiplyScalar(factor);
+            controls.update();
+            speed = Math.min(speed * 1.05, 0.15);
+          }
+        }, 50);
+      }
+      function stopZoom() {
+        clearInterval(zoomInterval);
+      }
+      ['mousedown','touchstart'].forEach(ev => {
+        DOM.zoomInBtn.addEventListener(ev, () => startZoom('in'));
+        DOM.zoomOutBtn.addEventListener(ev, () => startZoom('out'));
+      });
+      ['mouseup','mouseleave','touchend'].forEach(ev => {
+        DOM.zoomInBtn.addEventListener(ev, stopZoom);
+        DOM.zoomOutBtn.addEventListener(ev, stopZoom);
+      });
+
       DOM.exportHashLogBtn.addEventListener('click', () => {
         exportToCSV(hashLog, 'hash_log.csv');
       });
@@ -2235,14 +2310,14 @@
     winners.forEach(token => {
       const li = document.createElement('li');
       li.textContent = `${token.symbol}: ${token.change}`;
-      li.className = "text-green-400";
+      li.className = "text-brand-blue";
       document.getElementById('inverse-winners-list').appendChild(li);
     });
 
     losers.forEach(token => {
       const li = document.createElement('li');
       li.textContent = `${token.symbol}: ${token.change}`;
-      li.className = "text-red-400";
+      li.className = "text-brand-orange";
       document.getElementById('inverse-losers-list').appendChild(li);
     });
   });
@@ -2293,14 +2368,14 @@
     winners.forEach(token => {
       const li = document.createElement('li');
       li.textContent = `${token.symbol}: ${token.change}`;
-      li.className = "text-green-400";
+      li.className = "text-brand-blue";
       document.getElementById('inverse-winners-list').appendChild(li);
     });
 
     losers.forEach(token => {
       const li = document.createElement('li');
       li.textContent = `${token.symbol}: ${token.change}`;
-      li.className = "text-red-400";
+      li.className = "text-brand-orange";
       document.getElementById('inverse-losers-list').appendChild(li);
     });
   });
@@ -2357,14 +2432,14 @@ document.addEventListener("DOMContentLoaded", () => {
   if (winList) winners.forEach(t => {
     const li = document.createElement("li");
     li.textContent = `${t.symbol}: ${t.change}`;
-    li.className = "text-blue-400";
+    li.className = "text-brand-blue";
     winList.appendChild(li);
   });
 
   if (loseList) losers.forEach(t => {
     const li = document.createElement("li");
     li.textContent = `${t.symbol}: ${t.change}`;
-    li.className = "text-red-500";
+    li.className = "text-brand-orange";
     loseList.appendChild(li);
   });
 
@@ -2429,24 +2504,6 @@ document.getElementById('chat-send')?.addEventListener('click', async () => {
   chat.innerHTML += `<div class='text-xs text-green-300'>GPT: ${data.response}</div>`;
 });
 </script><script>
-function openCMC(event) {
-    const tokenSymbol = event.target.closest('li')?.querySelector('.token-symbol')?.textContent?.trim().toLowerCase();
-    const tokenNameMap = {
-        eth: 'ethereum',
-        btc: 'bitcoin',
-        xrp: 'xrp',
-        ada: 'cardano',
-        bnb: 'binancecoin',
-        ltc: 'litecoin',
-        link: 'chainlink',
-        dot: 'polkadot',
-        sol: 'solana',
-        usdt: 'tether'
-    };
-    const cmcToken = tokenNameMap[tokenSymbol] || tokenSymbol;
-    window.open(`https://coinmarketcap.com/currencies/${cmcToken}/`, '_blank');
-}
-document.getElementById('token-list').addEventListener('click', openCMC);
 </script><script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script><script>
 async function connectWalletAndLoadOmniData() {
   if (typeof window.ethereum === 'undefined') {
@@ -2494,7 +2551,10 @@ async function loadInverseFromCMC() {
 
   const labels = sorted.map(coin => coin.symbol.toUpperCase());
   const values = sorted.map(coin => coin.price_change_percentage_24h);
-  const colors = values.map(v => v > 0 ? 'rgba(34,197,94,0.6)' : 'rgba(239,68,68,0.7)');
+  const style = getComputedStyle(document.documentElement);
+  const blue = style.getPropertyValue('--primary-color').trim() || '#87CEEB';
+  const orange = style.getPropertyValue('--secondary-color').trim() || '#ffbb33';
+  const colors = values.map(v => v > 0 ? blue : orange);
 
   const ctx = document.getElementById('inverseChart').getContext('2d');
   new Chart(ctx, {
@@ -2512,7 +2572,7 @@ async function loadInverseFromCMC() {
       plugins: { legend: { display: false } },
       scales: {
         x: {
-          ticks: { color: '#ccc' },
+          ticks: { color: (ctx) => colors[ctx.index] },
           grid: { color: 'rgba(255,255,255,0.1)' }
         },
         y: {
@@ -2566,7 +2626,14 @@ async function loadInverseChart(topCount = 10) {
 
     const labels = filteredTokens.map(t => t.symbol.toUpperCase());
     const data = filteredTokens.map(t => t.price_change_percentage_24h);
-    const bgColor = data.map(change => isMarketDown ? (change > 0 ? '#3b82f6' : '#ef4444') : (change < 0 ? '#ef4444' : '#3b82f6'));
+    const style = getComputedStyle(document.documentElement);
+    const blue = style.getPropertyValue('--primary-color').trim() || '#87CEEB';
+    const orange = style.getPropertyValue('--secondary-color').trim() || '#ffbb33';
+    const bgColor = data.map(change =>
+        isMarketDown
+            ? (change > 0 ? blue : orange)
+            : (change < 0 ? orange : blue)
+    );
 
     const ctx = document.getElementById('inverseChart').getContext('2d');
     if (inverseChart) inverseChart.destroy();
@@ -2594,7 +2661,9 @@ async function loadInverseChart(topCount = 10) {
                     ticks: { color: '#ffffff' }
                 },
                 x: {
-                    ticks: { color: '#ffffff' }
+                    ticks: {
+                        color: (ctx) => bgColor[ctx.index]
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add brand color utility classes
- smooth zoom acceleration for BTC visualization
- color inverse chart bars with brand palette
- use brand colors for inverse winners/losers lists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68515ae9f098832aa2044a9054841fd3