### PR TITLE
Improve loading screen autoplay and wallet

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -308,7 +308,14 @@ app.get('/api/wallet', async (req, res) => {
     const omniData = omniResp.data || {};
 
     const tokenResp = await axios.get(`https://api.ethplorer.io/getAddressInfo/${address}?apiKey=freekey`);
-    const tokenCount = tokenResp.data.tokens ? tokenResp.data.tokens.length : 0;
+    const tokensRaw = tokenResp.data.tokens || [];
+    const tokenCount = tokensRaw.length;
+    const tokens = tokensRaw.map(t => ({
+      symbol: t.tokenInfo.symbol,
+      name: t.tokenInfo.name,
+      address: t.tokenInfo.address,
+      balance: t.balance / Math.pow(10, t.tokenInfo.decimals || 0)
+    }));
 
     const txResp = await axios.get(ETHERSCAN_API_URL, {
       params: {
@@ -328,6 +335,7 @@ app.get('/api/wallet', async (req, res) => {
       accountBalance: omniData.account?.balanceUsd || 'N/A',
       positions: omniData.positions || [],
       tokenCount,
+      tokens,
       lastTx
     });
   } catch (error) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,8 +93,21 @@
       padding: 0.5rem;
       border-radius: 0.25rem;
       cursor: pointer;
-      z-index: 1001;
+      z-index: 1002;
       pointer-events: auto;
+    }
+    #play-trailer-btn {
+      position: absolute;
+      bottom: 1rem;
+      left: 1rem;
+      opacity: 0.7;
+      background: rgba(0,0,0,0.5);
+      color: #fff;
+      border: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.25rem;
+      cursor: pointer;
+      z-index: 1002;
     }
     @media (max-width: 640px) {
       #mute-btn { padding: 0.25rem; font-size: 0.75rem; }
@@ -194,9 +207,15 @@
       flex-direction: column;
       align-items: center;
     }
+    .dj-track .playlist-container {
+      width: 500px;
+      height: 250px;
+      max-width: 100%;
+      aspect-ratio: auto;
+    }
     .dj-track iframe {
       width: 100%;
-      height: 200px;
+      height: 100%;
       border-radius: 6px;
     }
     .dj-overlay {
@@ -269,26 +288,38 @@
       z-index: 1;
     }
     .vinyl-disk {
+      position: relative;
       width: 80%;
       max-width: 400px;
       aspect-ratio: 1 / 1;
       border-radius: 50%;
       margin: 0.5rem auto;
-      background: radial-gradient(circle, rgba(255,255,255,0.1) 40%, rgba(0,0,0,0.6) 80%);
+      background: radial-gradient(circle, rgba(255,255,255,0.15) 5%, rgba(255,255,255,0.05) 40%, rgba(0,0,0,0.6) 80%);
       border: 3px solid rgba(135,206,235,0.6);
       box-shadow: 0 0 8px rgba(135,206,235,0.4);
       backdrop-filter: blur(2px);
       opacity: 0.85;
       transition: box-shadow 0.3s ease, border-color 0.3s ease;
     }
+    .vinyl-disk::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 20%;
+      height: 20%;
+      border-radius: 50%;
+      background: rgba(0,0,0,0.3);
+      transform: translate(-50%, -50%);
+    }
     .vinyl-disk.spinning {
       animation: spin 3s linear infinite;
-      border-color: rgba(135,206,235,0.8);
-      box-shadow: 0 0 12px rgba(135,206,235,0.8);
+      border-color: var(--primary-color);
+      box-shadow: 0 0 12px var(--primary-color);
     }
     .vinyl-disk.paused {
-      border-color: rgba(255,0,0,0.8);
-      box-shadow: 0 0 12px rgba(255,0,0,0.8);
+      border-color: var(--secondary-color);
+      box-shadow: 0 0 12px var(--secondary-color);
     }
     @media (max-width: 640px) {
       .vinyl-disk {
@@ -1025,15 +1056,16 @@
         <span id="loading-time"></span>
         <span id="loading-date"></span>
       </div>
+      <button id="mute-btn" aria-label="Toggle mute">🔇</button>
+      <button id="play-trailer-btn" aria-label="Play trailer">▶️ Play</button>
     </div>
-    <button id="mute-btn" aria-label="Toggle mute">🔇</button>
     <button id="skip-intro-btn" aria-label="Skip intro" onclick="hideLoadingScreen()">Skip Intro</button>
   </div>
   <div class="title-box">
     <h1 class="text-2xl md:text-3xl main-title">⚛️ QUANTUMI 🌌</h1>
   </div>
 </div>
-<div class="spline-bg" id="spline-bg">
+<div class="spline-bg hidden" id="spline-bg">
 <spline-viewer url="https://prod.spline.design/fJRTSatt5qGHtFUW/scene.splinecode"></spline-viewer>
 </div>
 <div class="particles" id="particles"></div>
@@ -1057,8 +1089,9 @@
 <button aria-label="Toggle QuantumI indicator" data-tooltip="Toggle QuantumI indicator" id="toggle-indicator-header" role="button">Toggle Indicator</button>
 <button aria-label="Open chart in modal" data-tooltip="Open chart in modal" id="toggle-sticky-header" role="button">Dock Chart</button>
 <button aria-label="Dock background in modal" data-tooltip="Dock background in modal" id="toggle-background" role="button">Dock Background</button>
-<button aria-label="Turn off background" data-tooltip="Turn off background to speed up the site" id="toggle-background-dock" role="button">Turn Off Background</button>
+<button aria-label="Turn on background" data-tooltip="Enable 3D background (may slow site)" id="toggle-background-dock" role="button">Turn On Background</button>
 </div>
+<div class="data-warning" id="background-warning" style="display: none;">⚠️ 3D background may slow down the site</div>
 </div>
 <div class="flex justify-between items-center mb-4 flex-wrap gap-2">
 <div class="text-sm" id="live-price-header">&gt; Live Price: Loading...</div>
@@ -1261,6 +1294,8 @@
 <p><strong>Wallet Address:</strong> <span id="wallet-address">Not connected</span></p>
 <p><strong>ETH Balance:</strong> <span id="wallet-balance">-</span></p>
 <p><strong>Detected Exchange:</strong> <span id="detected-exchange">Scanning...</span></p>
+<p><strong>Token Count:</strong> <span id="token-count">0</span></p>
+<p><strong>Last Tx:</strong> <span id="last-tx">N/A</span></p>
 </div>
 <ul class="list-disc ml-4 text-sm text-gray-300" id="open-trades"></ul>
 </div>
@@ -1349,7 +1384,7 @@
     <button id="dj-dock-btn" class="dj-btn ml-2">Dock DJ</button>
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
-    <div class="dj-track flex-1">
+    <div class="dj-track flex-1" draggable="true">
       <div class="mb-1 flex justify-center gap-2">
         <input id="track-a-url" class="p-1 rounded text-sm" value="https://www.youtube.com/playlist?list=PLjyTw1v0Tp27WoFeOITARFdNy_bEyFQu2"/>
         <button id="track-a-load" class="dj-btn">Load A</button>
@@ -1366,7 +1401,7 @@
       </div>
       <div class="vinyl-disk paused" id="vinyl-a"></div>
     </div>
-    <div class="dj-track flex-1">
+    <div class="dj-track flex-1" draggable="true">
       <div class="mb-1 flex justify-center gap-2">
         <input id="track-b-url" class="p-1 rounded text-sm" value="https://www.youtube.com/playlist?list=PLjyTw1v0Tp242zNBCT6whi48bEK3gP3Yj"/>
         <button id="track-b-load" class="dj-btn">Load B</button>
@@ -1455,6 +1490,7 @@
       musicMuteBtn: document.getElementById('music-mute-btn'),
       quantumiSoundBtn: document.getElementById('quantumi-sound-btn'),
       skipIntroBtn: document.getElementById('skip-intro-btn'),
+      playTrailerBtn: document.getElementById('play-trailer-btn'),
       loadingPrice: document.getElementById('loading-price'),
       loadingTopcoin: document.getElementById('loading-topcoin'),
       loadingInverse: document.getElementById('loading-inverse'),
@@ -1538,12 +1574,22 @@
                 e.target.setVolume(100);
                 e.target.playVideo();
                 routeYTSignal();
+                setTimeout(() => e.target.playVideo(), 100);
               }, 1000);
               e.target.getIframe().setAttribute('loading','lazy');
+              if (DOM.playTrailerBtn) DOM.playTrailerBtn.style.display = 'none';
             } catch {}
           }
         }
       });
+      setTimeout(() => {
+        try {
+          if (ytPlayer && ytPlayer.getPlayerState && ytPlayer.getPlayerState() !== YT.PlayerState.PLAYING) {
+            ytPlayer.playVideo();
+            if (DOM.playTrailerBtn) DOM.playTrailerBtn.style.display = 'none';
+          }
+        } catch {}
+      }, 7000);
 
       bgMusicPlayer = new YT.Player('music-player', {
         host: 'https://www.youtube-nocookie.com',
@@ -1572,14 +1618,17 @@
         host: 'https://www.youtube-nocookie.com',
         height: '100%',
         width: '100%',
-        playerVars: { listType: 'playlist', list: PLAYLIST_A, autoplay: 1, mute: 1 },
+        playerVars: { listType: 'playlist', list: PLAYLIST_A, autoplay: 0, mute: 1 },
         events: {
           onReady: (ev) => {
             attachTrack(ev.target, 'A');
             if (bgMusicPlayer) bgMusicPlayer.loadPlaylist({list: PLAYLIST_A});
             ev.target.getIframe().setAttribute('loading','lazy');
           },
-          onStateChange: () => updateVinyl('A')
+          onStateChange: (ev) => {
+            if (ev.data === YT.PlayerState.PLAYING) attachTrack(ev.target, 'A');
+            updateVinyl('A');
+          }
         }
       });
 
@@ -1587,14 +1636,17 @@
         host: 'https://www.youtube-nocookie.com',
         height: '100%',
         width: '100%',
-        playerVars: { listType: 'playlist', list: PLAYLIST_B, autoplay: 1, mute: 1 },
+        playerVars: { listType: 'playlist', list: PLAYLIST_B, autoplay: 0, mute: 1 },
         events: {
           onReady: (ev) => {
             attachTrack(ev.target, 'B');
             if (bgMusicPlayer) bgMusicPlayer.loadPlaylist({list: PLAYLIST_B});
             ev.target.getIframe().setAttribute('loading','lazy');
           },
-          onStateChange: () => updateVinyl('B')
+          onStateChange: (ev) => {
+            if (ev.data === YT.PlayerState.PLAYING) attachTrack(ev.target, 'B');
+            updateVinyl('B');
+          }
         }
       });
 
@@ -2185,7 +2237,7 @@
       const container = document.getElementById('btc-hash-canvas');
       renderer.setSize(container.clientWidth, container.clientHeight);
       container.appendChild(renderer.domElement);
-      camera.position.set(0, 0, 30);
+      camera.position.set(0, 0, 0.25);
       camera.lookAt(0, 0, 0);
 
       const ambientLight = new THREE.AmbientLight(0x404040);
@@ -2309,19 +2361,28 @@
         const geometry = new THREE.BufferGeometry();
         geometry.setAttribute('position', new THREE.Float32BufferAttribute(dotPositions, 3));
         geometry.setAttribute('color', new THREE.Float32BufferAttribute(dotColors, 3));
-        const material = new THREE.PointsMaterial({ size: 0.1, vertexColors: true });
+        const material = new THREE.PointsMaterial({ size: 0.1, vertexColors: true, transparent: true, opacity: 1 });
         const newDotCloud = new THREE.Points(geometry, material);
         scene.add(newDotCloud);
         dotClouds.push(newDotCloud);
+        dotClouds.slice(0, -1).forEach(cloud => {
+          cloud.material.opacity = cloud.material.opacity - 0.05 <= 0.1 ? 1 : cloud.material.opacity - 0.05;
+        });
 
         const latestPrice = prices[prices.length - 1][1];
         const latestVolume = volumes[volumes.length - 1][1];
         const latestTime = new Date(timestamps[timestamps.length - 1]).toLocaleTimeString();
+        const recentPrices = prices.slice(-10).map(p => p[1]);
+        const volatility = ((Math.max(...recentPrices) - Math.min(...recentPrices)) / latestPrice) * 100;
+        const momentum = latestPrice - prices[prices.length - 2][1];
         colorLegend.push({ color: siteColors[colorIndex], price: latestPrice, volume: latestVolume, time: latestTime });
         updateColorLegend();
 
         document.getElementById('btc-price').textContent = `Price: $${latestPrice.toLocaleString()}`;
         document.getElementById('btc-time').textContent = `Time: ${latestTime}`;
+        document.getElementById('btc-volume').textContent = `Volume: ${latestVolume.toLocaleString()}`;
+        document.getElementById('btc-volatility').textContent = `Volatility: ${volatility.toFixed(2)}%`;
+        document.getElementById('btc-momentum').textContent = `Momentum: ${momentum >= 0 ? '+' : ''}${momentum.toFixed(2)}`;
         if (DOM.playlistPrice) DOM.playlistPrice.textContent = `Price: $${latestPrice.toLocaleString()}`;
         if (DOM.playlistTime) DOM.playlistTime.textContent = `Time: ${latestTime}`;
         if (DOM.playlistDate) DOM.playlistDate.textContent = new Date().toLocaleDateString();
@@ -2752,13 +2813,15 @@
       }
 
       DOM.loaderBalances.style.display = 'none';
-      DOM.balancesList.innerHTML = balances.map(balance => `
+      DOM.balancesList.innerHTML = balances.map(balance => {
+        const slug = (balance.name || balance.token).toLowerCase().replace(/\s+/g, '-');
+        return `
         <li class="p-2 rounded">
-          <div>Token: ${balance.token}</div>
+          <a href="https://coinmarketcap.com/currencies/${slug}/" target="_blank" class="text-blue-400 underline token-link">${balance.token}</a>
           <div>Balance: ${balance.balance.toLocaleString()}</div>
           <div class="metric">Chain ID: ${balance.chainId}</div>
-        </li>
-      `).join('');
+        </li>`;
+      }).join('');
     }
 
     function updateTokenInsightsUI(insights) {
@@ -2822,6 +2885,14 @@
           } else {
             ytPlayer.mute();
             DOM.muteBtn.textContent = '🔇';
+          }
+        });
+      }
+      if (DOM.playTrailerBtn) {
+        DOM.playTrailerBtn.addEventListener('click', () => {
+          if (ytPlayer) {
+            ytPlayer.playVideo();
+            DOM.playTrailerBtn.style.display = 'none';
           }
         });
       }
@@ -3157,6 +3228,8 @@
         DOM.toggleBackgroundDockBtn.textContent = isHidden ? 'Turn On Background' : 'Turn Off Background';
         DOM.toggleBackgroundDockBtn.setAttribute('aria-label', isHidden ? 'Turn on background' : 'Turn off background');
         DOM.toggleBackgroundDockBtn.setAttribute('data-tooltip', isHidden ? 'Turn on background' : 'Turn off background to speed up the site');
+        const bgWarn = document.getElementById('background-warning');
+        if (bgWarn) bgWarn.style.display = isHidden ? 'none' : 'block';
       });
 
       DOM.splineModalCloseBtn.addEventListener('click', () => {
@@ -3268,12 +3341,21 @@
 
       let zoomDirection = 0;
       let zoomSpeed = 0;
+      const basePos = new THREE.Vector3(0,0,0.25);
+      const maxZoom = 5;
+      let autoReturn = false;
       function zoomLoop() {
         if (zoomDirection !== 0 && camera) {
           zoomSpeed = Math.min(zoomSpeed + 0.0008, 0.04);
           const factor = zoomDirection > 0 ? 1 - zoomSpeed : 1 + zoomSpeed;
           camera.position.multiplyScalar(factor);
+          if (camera.position.length() > maxZoom) {
+            camera.position.setLength(maxZoom);
+          }
           controls.update();
+        } else if (autoReturn) {
+          camera.position.lerp(basePos, 0.05);
+          if (camera.position.distanceTo(basePos) < 0.1) autoReturn = false;
         } else {
           zoomSpeed = 0;
         }
@@ -3286,7 +3368,7 @@
       });
       ['mouseup','mouseleave','touchend'].forEach(ev => {
         DOM.zoomInBtn.addEventListener(ev, () => { zoomDirection = 0; });
-        DOM.zoomOutBtn.addEventListener(ev, () => { zoomDirection = 0; });
+        DOM.zoomOutBtn.addEventListener(ev, () => { zoomDirection = 0; if (camera.position.length() >= maxZoom) autoReturn = true; });
       });
 
       DOM.exportHashLogBtn.addEventListener('click', () => {
@@ -3364,6 +3446,15 @@ document.getElementById('chat-send')?.addEventListener('click', async () => {
 let walletAddress = null;
 let balanceVisible = true;
 
+const savedWallet = localStorage.getItem('walletAddress');
+if (savedWallet) {
+  walletAddress = savedWallet;
+  document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('wallet-address').innerText = walletAddress;
+    refreshWalletData();
+  });
+}
+
 async function connectWallet() {
   if (typeof window.ethereum === 'undefined') {
     if (/Mobi|Android/i.test(navigator.userAgent)) {
@@ -3379,6 +3470,7 @@ async function connectWallet() {
     const signer = provider.getSigner();
     walletAddress = await signer.getAddress();
     document.getElementById('wallet-address').innerText = walletAddress;
+    localStorage.setItem('walletAddress', walletAddress);
     await refreshWalletData();
   } catch (err) {
     console.error('Wallet connection failed:', err);
@@ -3399,6 +3491,9 @@ async function refreshWalletData() {
     balEl.innerText = balanceVisible ? balanceTxt : '****';
     document.getElementById('detected-exchange').innerText = data.dex + (data.accountBalance ? ` (${data.accountBalance} USD)` : '');
 
+    document.getElementById('token-count').innerText = data.tokenCount;
+    document.getElementById('last-tx').innerText = data.lastTx;
+
     const tradesEl = document.getElementById('open-trades');
     tradesEl.innerHTML = '';
     data.positions.forEach(p => {
@@ -3406,6 +3501,11 @@ async function refreshWalletData() {
       li.innerHTML = `${p.symbol} | Size: ${p.size} <button class="close-trade" data-symbol="${p.symbol}" data-size="${p.size}">Close</button>`;
       tradesEl.appendChild(li);
     });
+
+    if (Array.isArray(data.tokens)) {
+      balancesData = data.tokens.map(t => ({ token: t.symbol, balance: t.balance, chainId: 1, name: t.name }));
+      updateBalancesUI(balancesData);
+    }
   } catch (e) {
     console.error('refreshWalletData error', e);
     document.getElementById('open-trades').innerHTML = '<li>Error loading wallet</li>';


### PR DESCRIPTION
## Summary
- ensure autoplay fallback triggers after 7 seconds
- keep trailer controls overlayed on video container
- refine transparent vinyl design
- start BTC hash view at center with shorter zoom limit
- remember connected wallet address

## Testing
- `npm run test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852924fa080832a962c9ffd316ba211