### PR TITLE
Fix title centering and Z0 zoom

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -785,12 +785,14 @@
       border: 2px solid var(--primary-color);
       border-radius: 6px;
       padding: 0.75rem 1rem;
-      animation: pulse 4s infinite;
       box-shadow: 0 0 4px var(--shadow-color);
       display: flex;
       justify-content: center;
       max-width: max-content;
       box-sizing: border-box;
+    }
+    .title-box h1 {
+      animation: pulse 4s infinite;
     }
     header .title-box {
       margin-top: 1rem;
@@ -3558,7 +3560,7 @@
 
       if (DOM.zoomZ0Btn) {
         DOM.zoomZ0Btn.addEventListener('click', () => {
-          camera.position.set(0, 0, 0);
+          camera.position.set(0, 0, 1);
           autoReturn = false;
           controls.update();
         });


### PR DESCRIPTION
## Summary
- keep loading screen title centered by moving pulse animation to the `<h1>` element
- adjust Z0 zoom button to start from z = 1 so orbit controls still work

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852f67a19e0832a8f53ca9ec7137629