### PR TITLE
Add Drift SDK example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ docker-compose up -d
 ```bash
 yarn start
 ```
+
+# Drift SDK Project
+
+The `drift-sdk-project` folder contains a minimal example showing how to use the
+[Drift Protocol](https://github.com/drift-labs/protocol-v2) SDK. To try it out:
+
+```bash
+cd drift-sdk-project
+npm install
+npm start
+```
+
+This script initializes a `DriftClient`. Extend it with your own trading logic.

--- a/drift-sdk-project/README.md
+++ b/drift-sdk-project/README.md
@@ -1,0 +1,23 @@
+# Drift SDK Project
+
+This folder contains a minimal example that demonstrates how to use the
+[Drift Protocol](https://github.com/drift-labs/protocol-v2) SDK. It assumes the
+SDK is available on npm as `@drift-labs/sdk`.
+
+## Setup
+
+```bash
+cd drift-sdk-project
+npm install
+```
+
+## Usage
+
+Run the example script:
+
+```bash
+npm start
+```
+
+The example initializes a `DriftClient`. Extend `index.js` with your own logic
+(for example fetching markets or placing orders).

--- a/drift-sdk-project/index.js
+++ b/drift-sdk-project/index.js
@@ -1,0 +1,13 @@
+const { DriftClient } = require('@drift-labs/sdk');
+
+async function main() {
+  // Initialize the Drift client (example endpoint)
+  const client = new DriftClient({ endpoint: 'https://api.drift.trade' });
+  console.log('Drift client initialized');
+  // Add your logic here, e.g., fetch markets or place orders
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/drift-sdk-project/package.json
+++ b/drift-sdk-project/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "drift-sdk-project",
+  "version": "0.1.0",
+  "description": "Example project using Drift Protocol SDK",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "@drift-labs/sdk": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `drift-sdk-project` example folder using the Drift Protocol SDK
- document the new project and how to run it in the main README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8bcdd46c832aaaee1c9a2718eae6