### PR TITLE
Add Quantumi tokens to main index

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,9 @@ A static website displaying low-volume tokens and real-time TradingView alerts f
 ## Integration
 
 1. **Verify Files**:
-   - Ensure `frontend/` contains: `index.html`, `script.js`, `styles.css`, `package.json`, `tailwind.config.js`, `README.md`.
+   - Ensure `frontend/` contains: `index.html, index-2025.html`, `script.js`, `styles.css`, `package.json`, `tailwind.config.js`, `README.md`.
+   - `index-2025.html` offers an experimental 2025-ready layout with gesture-ready controls.
+   - The primary `index.html` now incorporates the same Quantumi design tokens for consistent branding.
 
 2. **Configure Better Stack**:
    - `script.js` uses ClickHouse credentials (username: `ua439SvEJ8fzbFUfZLgfrngQ0hPAJWpeW`, password: `ACTAv2qyDnjVwEoeByXTZzY7LT0CBcT4Zd86AjYnE7fy6kPB5TYr4pjFqIfTjiPs`) for `t371838.ice_king_logs`.

--- a/frontend/index-2025.html
+++ b/frontend/index-2025.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>QUANTUMI Dashboard 2025</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --quantumi-green: #00FF7E;
+      --quantumi-black: #010101;
+      --quantumi-white: #F8F8F8;
+      --quantumi-gray: #1A1A1A;
+      --quantumi-accent: #FFD966;
+      --quantumi-radius: 18px;
+      --quantumi-blur: 18px;
+      --quantumi-glow: 0 0 20px var(--quantumi-green);
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100vw;
+      height: 100vh;
+      font-family: 'Inter', 'Segoe UI', sans-serif;
+      background-color: var(--quantumi-black);
+      color: var(--quantumi-white);
+      overflow: hidden;
+    }
+
+    .container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      padding: 1rem;
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      backdrop-filter: blur(var(--quantumi-blur));
+      background: rgba(0,0,0,0.6);
+      border-radius: var(--quantumi-radius);
+      box-shadow: var(--quantumi-glow);
+      z-index: 100;
+    }
+
+    .logo {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: var(--quantumi-green);
+      letter-spacing: 0.05em;
+    }
+
+    nav {
+      display: flex;
+      gap: 2rem;
+    }
+
+    nav a {
+      color: var(--quantumi-white);
+      text-decoration: none;
+      font-size: 1rem;
+      transition: color 0.3s ease;
+    }
+
+    nav a:hover {
+      color: var(--quantumi-green);
+    }
+
+    .mode-switch {
+      position: fixed;
+      top: 5rem;
+      right: 2rem;
+      background: var(--quantumi-gray);
+      color: var(--quantumi-white);
+      padding: 0.6rem 1.4rem;
+      border-radius: var(--quantumi-radius);
+      font-size: 0.9rem;
+      z-index: 10;
+      box-shadow: var(--quantumi-glow);
+      cursor: pointer;
+      user-select: none;
+    }
+
+    #visualization {
+      width: 100%;
+      height: 100%;
+      background: black;
+      border-radius: var(--quantumi-radius);
+      overflow: hidden;
+    }
+
+    footer {
+      text-align: center;
+      font-size: 0.8rem;
+      color: var(--quantumi-gray);
+      padding: 0.5rem 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div class="logo">QUANTUMI</div>
+      <nav>
+        <a href="#">Home</a>
+        <a href="/investor.html">Investor Hub</a>
+        <a href="#">Mint</a>
+        <a href="#">Whitepaper</a>
+      </nav>
+    </header>
+
+    <div id="visualization">
+      <!-- Future 3D BTC Hash Visualizer -->
+    </div>
+
+    <footer>
+      © QUANTUMI 2025. All Rights Reserved.
+    </footer>
+  </div>
+
+  <div class="mode-switch">Mode: Raw Hash</div>
+
+  <script>
+    document.querySelector('.mode-switch').addEventListener('click', () => {
+      alert('Mode switch gesture detected');
+    });
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'm') {
+        alert('Mode toggled via brain/keyboard');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,12 +24,16 @@
 			href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
 			rel="stylesheet"
 		/>
-		<link href="https://fonts.googleapis.com" rel="preconnect" />
-		<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&amp;family=Limelight&amp;display=swap"
-			rel="stylesheet"
-		/>
+                <link href="https://fonts.googleapis.com" rel="preconnect" />
+                <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+                <link
+                        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+                        rel="stylesheet"
+                />
+                <link
+                        href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&amp;family=Limelight&amp;display=swap"
+                        rel="stylesheet"
+                />
 		<link
 			href="https://fonts.googleapis.com/css2?family=Sixtyfour&amp;display=swap"
 			rel="stylesheet"
@@ -61,16 +65,25 @@
 			src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/exporters/FBXExporter.js"
 		></script>
 		<script src="https://www.youtube.com/iframe_api"></script>
-		<style>
-			:root {
-				--bg-color: #121212;
-				--text-color: #e0f7fa;
-				--primary-color: #87ceeb;
-				--secondary-color: #ffbb33;
-				--shadow-color: rgba(135, 206, 235, 0.3);
-			}
+                <style>
+                        :root {
+                                --quantumi-green: #00FF7E;
+                                --quantumi-black: #010101;
+                                --quantumi-white: #F8F8F8;
+                                --quantumi-gray: #1A1A1A;
+                                --quantumi-accent: #FFD966;
+                                --quantumi-radius: 18px;
+                                --quantumi-blur: 18px;
+                                --quantumi-glow: 0 0 20px var(--quantumi-green);
+
+                                --bg-color: var(--quantumi-black);
+                                --text-color: var(--quantumi-white);
+                                --primary-color: var(--quantumi-green);
+                                --secondary-color: var(--quantumi-accent);
+                                --shadow-color: rgba(0, 255, 126, 0.3);
+                        }
                         body {
-                                font-family: 'Inconsolata', monospace;
+                                font-family: 'Inter', 'Segoe UI', sans-serif;
                                 background: var(--bg-color);
                                 color: var(--text-color);
                                 margin: 0;
@@ -7068,6 +7081,18 @@ function setupModuleToggles() {
                                                 error.classList.remove('hidden');
                                         }
                                 });
+                        });
+                </script>
+                <div class="mode-switch">Mode: Raw Hash</div>
+                <div id="visualization"><!-- Future 3D BTC Hash Visualizer --></div>
+                <script>
+                        document.querySelector('.mode-switch').addEventListener('click', () => {
+                                alert('Mode switch gesture detected');
+                        });
+                        window.addEventListener('keydown', (e) => {
+                                if (e.key === 'm') {
+                                        alert('Mode toggled via brain/keyboard');
+                                }
                         });
                 </script>
         </body>


### PR DESCRIPTION
## Summary
- apply Quantumi 2025 design tokens and Inter font to `index.html`
- add mode switch placeholder and 3D visualization container
- document updated styling in the frontend README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688209835944832abc421c0ba7e211e8