### PR TITLE
Fix BTC legend overlay size

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1933,6 +1933,8 @@
                                 flex-wrap: wrap;
                                 justify-content: center;
                                 gap: 0.25rem;
+                                padding: 0.5rem;
+                                font-size: clamp(8px, 1.2vw, 12px);
                                 pointer-events: none;
                         }
                         .nav-link {


### PR DESCRIPTION
## Summary
- keep BTC hash legend overlay from obscuring the chart
- apply padding and small text size

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d46261178832a8ed3a242b12edb33