### PR TITLE
Fix BTC legend overlay size

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -419,6 +419,9 @@
                                 transform: none;
                                 width: 100%;
                                 padding: 0.5rem;
+                                min-height: 2rem;
+                                display: flex;
+                                align-items: center;
                         }
                         #btc-metrics-overlay .metrics-container {
                                 gap: 2px;
@@ -1925,14 +1928,19 @@
                                 position: absolute;
                                 bottom: 0;
                                 left: 0;
+                                right: 0;
                                 margin-top: 0;
                                 width: 100%;
                                 background: rgba(0, 0, 0, 0.2);
                                 z-index: 20;
                                 display: flex;
+                                align-items: center;
                                 flex-wrap: wrap;
                                 justify-content: center;
                                 gap: 0.25rem;
+                                padding: 0.5rem;
+                                min-height: 2rem;
+                                font-size: clamp(8px, 1.2vw, 12px);
                                 pointer-events: none;
                         }
                         .nav-link {
@@ -3547,7 +3555,7 @@
 				gainNode;
                         const themes = {
                                 original: ['#00FF7E', '#00cc5b', '#009944', '#e0f7fa'],
-                                heatmap: ['#003a1c', '#00cc5b', '#00FF7E'],
+                                heatmap: ['#66ff66', '#ffff00', '#ff0000'],
                                 lifecycle: ['#003a1c', '#00cc5b', '#00FF7E']
                         };
                         let currentTheme = 'heatmap';
@@ -5059,7 +5067,18 @@ function setupModuleToggles() {
                         function getThemeColor(vol, volume, minV, maxV) {
                                 if (currentTheme === 'heatmap') {
                                         const ratio = Math.min(vol / 5, 1);
-                                        return interpolateColor(themes.heatmap[0], themes.heatmap[2], ratio);
+                                        if (ratio < 0.5) {
+                                                return interpolateColor(
+                                                        themes.heatmap[0],
+                                                        themes.heatmap[1],
+                                                        ratio * 2
+                                                );
+                                        }
+                                        return interpolateColor(
+                                                themes.heatmap[1],
+                                                themes.heatmap[2],
+                                                (ratio - 0.5) * 2
+                                        );
                                 } else if (currentTheme === 'lifecycle') {
                                         const ratio = (volume - minV) / (maxV - minV);
                                         if (ratio < 0.25) return themes.lifecycle[0];


### PR DESCRIPTION
## Summary
- keep BTC legend overlay from obscuring the chart
- apply padding and small text size
- refine overlay height and alignment
- set heatmap colors from green to yellow to red

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d46261178832a8ed3a242b12edb33