### PR TITLE
feat(frontend): add modern nextjs UI with 3d hero and bento grid

### DIFF
--- a/frontend/components/BentoGrid.tsx
+++ b/frontend/components/BentoGrid.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+
+interface Card {
+  id: number;
+  title: string;
+  className: string;
+}
+
+const initialCards: Card[] = [
+  { id: 1, title: 'Realtime Alerts', className: 'col-span-2 row-span-1' },
+  { id: 2, title: '3D Insights', className: 'row-span-2' },
+  { id: 3, title: 'Secure Wallets', className: '' },
+  { id: 4, title: 'Smart Routing', className: 'col-span-2' },
+];
+
+const BentoGrid = () => {
+  const [cards, setCards] = useState(initialCards);
+  useEffect(() => {
+    const handleResize = () => {
+      setCards((prev) => [...prev].sort(() => Math.random() - 0.5));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return (
+    <section className="p-4">
+      <div className="grid gap-4 grid-cols-2 md:grid-cols-4 auto-rows-[120px]">
+        {cards.map((card) => (
+          <motion.div
+            key={card.id}
+            whileHover={{ scale: 1.03 }}
+            className={`flex items-center justify-center bg-carbon rounded-xl text-white p-4 ${card.className}`}
+          >
+            <h3 className="text-lg font-semibold">{card.title}</h3>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default BentoGrid;

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import HeroCanvas from './HeroCanvas';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const Hero = () => {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    if (titleRef.current) {
+      gsap.fromTo(
+        titleRef.current,
+        { y: 50, opacity: 0 },
+        { y: 0, opacity: 1, duration: 1, ease: 'power3.out' }
+      );
+    }
+  }, []);
+
+  return (
+    <section className="relative flex flex-col items-center justify-center h-screen overflow-hidden">
+      <HeroCanvas />
+      <h1
+        ref={titleRef}
+        className="mt-8 text-5xl font-extrabold text-center text-accent"
+      >
+        APEX Omni Trading
+      </h1>
+    </section>
+  );
+};
+
+export default Hero;

--- a/frontend/components/HeroCanvas.tsx
+++ b/frontend/components/HeroCanvas.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+const HeroCanvas = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    const geometry = new THREE.IcosahedronGeometry(1, 1);
+    const material = new THREE.MeshStandardMaterial({ color: '#38bdf8', wireframe: true });
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const light = new THREE.PointLight(0xffffff, 1);
+    light.position.set(10, 10, 10);
+    scene.add(light);
+    camera.position.z = 5;
+
+    const resize = () => {
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    const animate = () => {
+      mesh.rotation.x += 0.005;
+      mesh.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      renderer.dispose();
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-[40vh]" />;
+};
+
+export default HeroCanvas;

--- a/frontend/components/KineticText.tsx
+++ b/frontend/components/KineticText.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+
+interface Props {
+  text: string;
+}
+
+const KineticText = ({ text }: Props) => (
+  <motion.h2
+    className="my-16 text-3xl font-bold text-center text-accent"
+    initial={{ opacity: 0, y: 40 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.6 }}
+    viewport={{ once: true }}
+  >
+    {text}
+  </motion.h2>
+);
+
+export default KineticText;

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+const ThemeToggle = () => {
+  const { theme, setTheme, systemTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  const current = theme === 'system' ? systemTheme : theme;
+  return (
+    <button
+      aria-label="Toggle Theme"
+      onClick={() => setTheme(current === 'dark' ? 'light' : 'dark')}
+      className="fixed top-4 right-4 z-50 p-2 rounded-md bg-carbon/60 backdrop-blur-md text-accent"
+    >
+      {current === 'dark' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,15 +1,26 @@
 {
-  "name": "ice-king-trading-dashboard",
+  "name": "apex-omni-frontend",
   "version": "1.0.0",
-  "description": "Static website for ICE KING trading dashboard with CoinGecko data and TradingView alerts",
+  "private": true,
   "scripts": {
-    "start": "npx serve .",
-    "build": "npm run zip",
-    "zip": "zip -r ice-king-trading-dashboard.zip . -x '*.git*'"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
   "dependencies": {
-    "serve": "^14.2.3"
+    "framer-motion": "^10.16.4",
+    "gsap": "^3.12.2",
+    "next": "^14.0.0",
+    "next-themes": "^0.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.158.0"
   },
-  "author": "",
-  "license": "MIT"
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.2.2"
+  }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,13 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'next-themes';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}
+
+export default MyApp;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,23 @@
+import Head from 'next/head';
+import Hero from '../components/Hero';
+import BentoGrid from '../components/BentoGrid';
+import KineticText from '../components/KineticText';
+import ThemeToggle from '../components/ThemeToggle';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>APEX Omni Trading</title>
+        <meta name="description" content="Next-gen trading dashboard" />
+      </Head>
+      <ThemeToggle />
+      <main className="min-h-screen bg-navy text-white">
+        
+        <Hero />
+        <KineticText text='Automate Your Strategy' />
+        <BentoGrid />
+      </main>
+    </>
+  );
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  @apply bg-navy text-white;
+}
+
+body {
+  @apply transition-colors duration-300 bg-navy text-white;
+}
+
+/* Grain overlay */
+body:before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.05;
+  z-index: 50;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,15 +1,21 @@
 module.exports = {
-  darkMode: 'media',
+  darkMode: 'class',
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
   theme: {
     extend: {
       colors: {
-        primary: '#0f172a',
-        secondary: '#1e293b',
+        navy: '#0a0e17',
+        carbon: '#1c1f23',
         accent: '#38bdf8',
-        success: '#10b981',
-        danger: '#ef4444',
+        muted: '#64748b'
       },
-    },
+      backdropBlur: {
+        xs: '2px'
+      }
+    }
   },
-  plugins: [],
+  plugins: []
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- overhaul frontend into Next.js with bento grid layout and kinetic typography
- add low-light theme toggle with grain overlay and blur effects
- embed lightweight Three.js hero animation for depth and motion

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e4956d8e8832a9f36848e011824c3