### PR TITLE
feat: add live metrics dashboard

### DIFF
--- a/frontend/components/ApexLiveMetrics.module.css
+++ b/frontend/components/ApexLiveMetrics.module.css
@@ -1,0 +1,62 @@
+.container {
+  width: 100%;
+  background: var(--color-bg-alt);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius);
+  box-shadow: 0 0 20px rgba(39, 174, 96, 0.25);
+}
+
+.heading {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-md);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius);
+  padding: var(--spacing-md);
+  box-shadow: 0 0 10px rgba(39, 174, 96, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 0 15px rgba(39, 174, 96, 0.3);
+}
+
+.label {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: var(--spacing-sm);
+}
+
+.value {
+  font-family: 'Roboto', 'Inter', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.positive {
+  color: #27ae60;
+}
+
+.negative {
+  color: #e74c3c;
+}
+
+.error,
+.loading {
+  padding: var(--spacing-md);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius);
+  text-align: center;
+}

--- a/frontend/components/ApexLiveMetrics.tsx
+++ b/frontend/components/ApexLiveMetrics.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { motion, useMotionValue, useTransform, animate } from 'framer-motion';
+import styles from './ApexLiveMetrics.module.css';
+import { useLiveMetrics } from './LiveMetricsContext';
+
+const CountUp = ({ value }: { value: number }) => {
+  const count = useMotionValue(0);
+  const rounded = useTransform(count, latest => Number(latest.toFixed(2)));
+  useEffect(() => {
+    const controls = animate(count, value, { duration: 0.8 });
+    return controls.stop;
+  }, [value, count]);
+  return <motion.span>{rounded}</motion.span>;
+};
+
+const ApexLiveMetrics = () => {
+  const { metrics, error } = useLiveMetrics();
+
+  if (error) {
+    return (
+      <div className={styles.error} role="alert">
+        {error}
+      </div>
+    );
+  }
+
+  if (!metrics) {
+    return <div className={styles.loading}>Loading...</div>;
+  }
+
+  const items = [
+    { label: 'Total Equity Value', value: metrics.totalEquityValue },
+    { label: 'Available Balance', value: metrics.availableBalance },
+    { label: 'Realized PnL', value: metrics.realizedPnl, isPnl: true },
+    { label: 'Unrealized PnL', value: metrics.unrealizedPnl, isPnl: true },
+    { label: 'Maintenance Margin', value: metrics.maintenanceMargin },
+    { label: 'Initial Margin', value: metrics.initialMargin },
+    { label: 'Total Risk', value: metrics.totalRisk },
+  ];
+
+  return (
+    <section className={styles.container} aria-labelledby="live-metrics-heading" aria-live="polite">
+      <h2 id="live-metrics-heading" className={styles.heading}>
+        Live Metrics
+      </h2>
+      <div className={styles.grid}>
+        {items.map(({ label, value, isPnl }) => (
+          <motion.div
+            key={label}
+            className={styles.card}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            title={label}
+          >
+            <span className={styles.label}>{label}</span>
+            <span
+              className={`${styles.value} ${
+                isPnl ? (value >= 0 ? styles.positive : styles.negative) : ''
+              }`}
+            >
+              <CountUp value={value} />
+            </span>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ApexLiveMetrics;
+

--- a/frontend/components/Hero.module.css
+++ b/frontend/components/Hero.module.css
@@ -9,25 +9,25 @@
 }
 
 .heading {
-  font-size: clamp(3rem, 6vw, 4rem);
+  font-size: clamp(3.5rem, 8vw, 5rem);
   font-weight: 700;
   color: var(--color-primary);
   margin: 0;
 }
 
 .subheading {
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   max-width: 600px;
   margin: 0 auto;
 }
 
 .cta {
-  padding: var(--spacing-sm) var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
   background: var(--color-primary);
   color: var(--color-bg);
   border: none;
   border-radius: var(--radius);
-  font-size: 1rem;
+  font-size: 1.125rem;
   cursor: pointer;
   transition: background 0.3s ease, box-shadow 0.3s ease;
 }
@@ -36,4 +36,21 @@
 .cta:focus {
   background: #1e8c4e;
   box-shadow: 0 0 15px rgba(39, 174, 96, 0.5);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .content {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .content > * {
+    flex: 1;
+  }
 }

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import TradingViewChart from './TradingViewChart';
+import ApexLiveMetrics from './ApexLiveMetrics';
 import styles from './Hero.module.css';
 
 const Hero = () => {
@@ -11,12 +12,37 @@ const Hero = () => {
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
     >
-      <h1 className={styles.heading}>ApexOmni Trading</h1>
-      <p className={styles.subheading}>
+      <motion.h1
+        className={styles.heading}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+      >
+        ApexOmni Trading
+      </motion.h1>
+      <motion.p
+        className={styles.subheading}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.1 }}
+      >
         Automate your strategies and monitor markets with real-time TradingView integration.
-      </p>
-      <button className={styles.cta}>Get Started</button>
-      <TradingViewChart />
+      </motion.p>
+      <motion.button
+        className={styles.cta}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.2 }}
+      >
+        Get Started
+      </motion.button>
+      <div className={styles.content}>
+        <ApexLiveMetrics />
+        <TradingViewChart />
+      </div>
     </motion.section>
   );
 };

--- a/frontend/components/LiveMetricsContext.tsx
+++ b/frontend/components/LiveMetricsContext.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface Metrics {
+  totalEquityValue: number;
+  availableBalance: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  maintenanceMargin: number;
+  initialMargin: number;
+  totalRisk: number;
+}
+
+interface LiveMetricsContextValue {
+  metrics: Metrics | null;
+  error: string | null;
+}
+
+const LiveMetricsContext = createContext<LiveMetricsContextValue>({
+  metrics: null,
+  error: null,
+});
+
+export const LiveMetricsProvider = ({ children }: { children: ReactNode }) => {
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMetrics = async () => {
+    try {
+      const timestamp = Date.now().toString();
+      const res = await fetch('https://omni.apex.exchange/api/v3/account-balance', {
+        headers: {
+          'APEX-SIGNATURE': process.env.NEXT_PUBLIC_APEX_SIGNATURE || '',
+          'APEX-API-KEY': process.env.NEXT_PUBLIC_APEX_API_KEY || '',
+          'APEX-TIMESTAMP': timestamp,
+          'APEX-PASSPHRASE': process.env.NEXT_PUBLIC_APEX_PASSPHRASE || '',
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+
+      const data = await res.json();
+      setMetrics({
+        totalEquityValue: data.totalEquityValue,
+        availableBalance: data.availableBalance,
+        realizedPnl: data.realizedPnl,
+        unrealizedPnl: data.unrealizedPnl,
+        maintenanceMargin: data.maintenanceMargin,
+        initialMargin: data.initialMargin,
+        totalRisk: data.totalRisk,
+      });
+      setError(null);
+    } catch (err) {
+      setError('Live data failed to load');
+    }
+  };
+
+  useEffect(() => {
+    fetchMetrics();
+    const id = setInterval(fetchMetrics, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <LiveMetricsContext.Provider value={{ metrics, error }}>
+      {children}
+    </LiveMetricsContext.Provider>
+  );
+};
+
+export const useLiveMetrics = () => useContext(LiveMetricsContext);
+

--- a/frontend/components/Navbar.module.css
+++ b/frontend/components/Navbar.module.css
@@ -7,12 +7,13 @@
   justify-content: space-between;
   align-items: center;
   padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--color-primary);
+  border-bottom: 2px solid var(--color-primary);
+  box-shadow: 0 2px 20px rgba(39, 174, 96, 0.25);
 }
 
 .logo {
   color: var(--color-primary);
-  font-size: 1.5rem;
+  font-size: 2rem;
   font-weight: 700;
 }
 
@@ -24,10 +25,11 @@
 .link {
   color: var(--color-text);
   text-decoration: none;
-  font-size: 1rem;
+  font-size: 1.125rem;
 }
 
 .link:hover,
 .link:focus {
   color: var(--color-primary);
+  text-shadow: 0 0 5px rgba(39, 174, 96, 0.6);
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,11 +2,14 @@ import '../styles/theme.css';
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from 'next-themes';
+import { LiveMetricsProvider } from '../components/LiveMetricsContext';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <Component {...pageProps} />
+      <LiveMetricsProvider>
+        <Component {...pageProps} />
+      </LiveMetricsProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -12,7 +12,10 @@ export default function Home() {
       <Head>
         <title>APEX Omni Trading</title>
         <meta name="description" content="Next-gen trading dashboard" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <Navbar />
       <main>


### PR DESCRIPTION
## Summary
- add live metrics context and card-based dashboard
- restyle hero and navbar with bold green theme
- load Roboto font for numeric displays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @types/react 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f312610d4832a953c42404427fdbf