### PR TITLE
feat: introduce green brand palette and scroll-snap layout

### DIFF
--- a/frontend/components/Hero.module.css
+++ b/frontend/components/Hero.module.css
@@ -8,36 +8,6 @@
   background: var(--color-bg);
 }
 
-.heading {
-  font-size: clamp(3.5rem, 8vw, 5rem);
-  font-weight: 700;
-  color: var(--color-primary);
-  margin: 0;
-}
-
-.subheading {
-  font-size: 1.5rem;
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.cta {
-  padding: var(--spacing-md) var(--spacing-lg);
-  background: var(--color-primary);
-  color: var(--color-bg);
-  border: none;
-  border-radius: var(--radius);
-  font-size: 1.125rem;
-  cursor: pointer;
-  transition: background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.cta:hover,
-.cta:focus {
-  background: #1e8c4e;
-  box-shadow: 0 0 15px rgba(39, 174, 96, 0.5);
-}
-
 .content {
   display: flex;
   flex-direction: column;

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -13,7 +13,7 @@ const Hero = () => {
       transition={{ duration: 0.6 }}
     >
       <motion.h1
-        className={styles.heading}
+        className="text-5xl sm:text-6xl font-bold mb-6 text-brand"
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -22,7 +22,7 @@ const Hero = () => {
         ApexOmni Trading
       </motion.h1>
       <motion.p
-        className={styles.subheading}
+        className="text-2xl sm:text-3xl font-semibold mb-4 leading-relaxed"
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -31,7 +31,7 @@ const Hero = () => {
         Automate your strategies and monitor markets with real-time TradingView integration.
       </motion.p>
       <motion.button
-        className={styles.cta}
+        className="bg-brand text-black rounded-2xl px-8 py-4 shadow-lg transition hover:shadow-[0_0_12px_var(--green)]"
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -18,7 +18,7 @@ export default function Home() {
         />
       </Head>
       <Navbar />
-      <main>
+      <main className="overflow-y-auto">
         <Hero />
         <AlertModule />
         <WebhookForm />

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -8,6 +8,15 @@ body {
   color: var(--color-text);
 }
 
+html {
+  scroll-snap-type: y mandatory;
+}
+
+section {
+  scroll-snap-align: start;
+  min-height: 100vh;
+}
+
 body {
   transition: background-color 0.3s ease, color 0.3s ease;
 }

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,5 +1,8 @@
 :root {
-  --color-primary: #27ae60;
+  --green-light: #E0FFE8;
+  --green: #00FF7E;
+  --green-dark: #00CC65;
+  --color-primary: var(--green);
   --color-bg: #0a0a0a;
   --color-bg-alt: #1a1a1a;
   --color-text: #ffffff;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,7 +10,12 @@ module.exports = {
         navy: '#0a0e17',
         carbon: '#1c1f23',
         accent: '#38bdf8',
-        muted: '#64748b'
+        muted: '#64748b',
+        brand: {
+          light: 'var(--green-light)',
+          DEFAULT: 'var(--green)',
+          dark: 'var(--green-dark)'
+        }
       },
       backdropBlur: {
         xs: '2px'


### PR DESCRIPTION
## Summary
- define green brand color variables and expose through Tailwind theme
- restyle hero header with responsive typography and brand button
- enable vertical scroll snapping for full screen modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend && npm run lint` *(fails: 403 Forbidden installing @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_6890073e4270832a8a823113896a9704