### PR TITLE
Fix login form layout on mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2046,7 +2046,7 @@
                         position: fixed;
                         inset: 0;
                         width: 100%;
-                        height: 100%;
+                        min-height: 100vh;
                         background: #111215;
                         z-index: 2000;
                         display: flex;
@@ -2054,6 +2054,10 @@
                         align-items: center;
                         justify-content: center;
                         color: #e3e3e3cc;
+                        padding: clamp(1.5em, 5vh, 3em) 1em;
+                        padding-bottom: calc(env(safe-area-inset-bottom) + clamp(1.5em, 5vh, 3em));
+                        box-sizing: border-box;
+                        overflow-y: auto;
                     }
                     .q-hero-canvas {
                         width: 100vw;
@@ -2077,7 +2081,7 @@
                         margin-bottom: 0.3em;
                     }
                     .login-form {
-                        width: 94vw;
+                        width: 100%;
                         max-width: 340px;
                         margin: 0 auto;
                         display: flex;
@@ -2166,6 +2170,12 @@
                     #overlay-description {
                         font-size: 0.875rem;
                         margin-top: 0.5rem;
+                    }
+                    @media (max-height: 700px) {
+                        #access-overlay {
+                            justify-content: flex-start;
+                            padding-top: 1em;
+                        }
                     }
                       @media (max-width: 600px) {
                           .branding { font-size: 8vw; }

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -34,7 +34,9 @@
       align-items: center;
       justify-content: center;
       padding: clamp(1.5em, 5vh, 3em) 1em;
+      padding-bottom: calc(env(safe-area-inset-bottom) + clamp(1.5em, 5vh, 3em));
       box-sizing: border-box;
+      overflow-y: auto;
     }
     .q-hero-canvas {
       width: 100%;
@@ -169,7 +171,7 @@
       background: #181b1e;
       color: #aaa;
       text-align: center;
-      padding: 1.2em 0 1.5em 0;
+      padding: 1.2em 0 calc(1.5em + env(safe-area-inset-bottom)) 0;
       border-top: 1px solid #222;
       font-size: 0.95em;
     }
@@ -184,6 +186,10 @@
       .branding { font-size: 8vw; }
     }
     @media (max-height: 700px) {
+      main {
+        justify-content: flex-start;
+        padding-top: 1em;
+      }
       .q-hero-canvas {
         height: clamp(150px, 25vh, 240px);
       }


### PR DESCRIPTION
## Summary
- make login forms scrollable and safely padded to avoid clipped buttons
- center login overlay on large screens and widen form to full width
- add fallback top alignment on short viewports for better access

## Testing
- `npm test`
- `(cd frontend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_6894043cb6fc832aacd8c905c82a06d0