### PR TITLE
feat: default Layer II logo with glowing toggles

### DIFF
--- a/frontend/index-2025.html
+++ b/frontend/index-2025.html
@@ -10,14 +10,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Sixtyfour:BLED,SCAN@0..100,-53..100&display=swap" rel="stylesheet">
   <style>
     :root {
-      --quantumi-green: #00FF7E;
+      --quantumi-green: #00FF00;
       --quantumi-black: #010101;
       --quantumi-white: #F8F8F8;
       --quantumi-gray: #1A1A1A;
       --quantumi-accent: #FFD966;
       --quantumi-radius: 18px;
       --quantumi-blur: 18px;
-      --quantumi-glow: 0 0 20px var(--quantumi-green);
     }
 
   html, body {
@@ -49,7 +48,7 @@
       backdrop-filter: blur(var(--quantumi-blur));
       background: rgba(0,0,0,0.6);
       border-radius: var(--quantumi-radius);
-      box-shadow: var(--quantumi-glow);
+      box-shadow: 0 0 24px #000b;
       z-index: 100;
     }
 
@@ -104,7 +103,7 @@
       border-radius: var(--quantumi-radius);
       font-size: 0.9rem;
       z-index: 10;
-      box-shadow: var(--quantumi-glow);
+      box-shadow: 0 0 24px #000b;
       cursor: pointer;
       user-select: none;
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -71,20 +71,19 @@
 		<script src="https://www.youtube.com/iframe_api"></script>
                 <style>
                         :root {
-                                --quantumi-green: #00FF7E;
+                                --quantumi-green: #00FF00;
                                 --quantumi-black: #010101;
                                 --quantumi-white: #F8F8F8;
                                 --quantumi-gray: #1A1A1A;
-                                --quantumi-accent: #00FF7E;
+                                --quantumi-accent: #00FF00;
                                 --quantumi-radius: 18px;
                                 --quantumi-blur: 18px;
-                                --quantumi-glow: 0 0 20px var(--quantumi-green);
 
                                 --bg-color: var(--quantumi-black);
                                 --text-color: var(--quantumi-white);
                                 --primary-color: var(--quantumi-green);
                                 --secondary-color: var(--quantumi-green);
-                                --shadow-color: rgba(0, 255, 126, 0.3);
+                                --shadow-color: rgba(0, 255, 0, 0.3);
                         }
                         body {
                                 font-family: 'Inter', 'Segoe UI', sans-serif;
@@ -1100,33 +1099,29 @@
                         #legend-toggle {
                                 padding: 0.65em 1.5em;
                                 font-size: clamp(13px, 2vw, 19px);
-                                background: #333;
+                                background: transparent;
                                 color: #fff;
-                                border: none;
+                                border: 1.5px solid rgba(0, 255, 0, 0.3);
                                 border-radius: 8px;
                                 cursor: pointer;
                                 font-family: inherit;
                                 font-weight: 500;
-                                transition: background-color 0.3s ease, color 0.3s ease;
+                                transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
                         }
-                        .toggle-module-btn:hover,
-                        .toggle-module-btn:focus,
-                        .toggle-module-btn:active,
+                        .toggle-module-btn:hover:not(.active),
+                        .toggle-desc-btn:hover:not(.active),
+                        #hash-log-toggle:hover:not(.active),
+                        #legend-toggle:hover:not(.active) {
+                                background: rgba(0, 255, 0, 0.15);
+                        }
                         .toggle-module-btn.active,
-                        .toggle-desc-btn:hover,
-                        .toggle-desc-btn:focus,
-                        .toggle-desc-btn:active,
                         .toggle-desc-btn.active,
-                        #hash-log-toggle:hover,
-                        #hash-log-toggle:focus,
-                        #hash-log-toggle:active,
                         #hash-log-toggle.active,
-                        #legend-toggle:hover,
-                        #legend-toggle:focus,
-                        #legend-toggle:active,
                         #legend-toggle.active {
-                                background: #00ff00;
+                                background: rgba(0, 255, 0, 0.4);
                                 color: #000;
+                                box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
+                                border-color: rgba(0, 255, 0, 0.8);
                         }
 			.module-content.hidden {
 				display: none;
@@ -2062,7 +2057,7 @@
                         display: flex;
                         flex-direction: column;
                         align-items: center;
-                        justify-content: center;
+                        justify-content: flex-start;
                         color: #e3e3e3cc;
                         padding: clamp(1.5em, 5vh, 3em) 1em;
                         padding-bottom: calc(env(safe-area-inset-bottom) + 2rem);
@@ -2160,13 +2155,13 @@
                         outline: none;
                     }
                     .btn.selected {
-                        background: rgba(0,255,126,0.3);
+                        background: rgba(0,255,0,0.3);
                         color: #fff;
-                        border-color: rgba(0,255,126,0.4);
+                        border-color: rgba(0,255,0,0.4);
                     }
                     .btn:hover:not(.selected),
                     .btn:focus:not(.selected) {
-                        background: rgba(0,255,126,0.2);
+                        background: rgba(0,255,0,0.2);
                         color: #fff;
                         transform: scale(1.04);
                     }
@@ -2184,7 +2179,6 @@
                     }
                     @media (max-height: 700px) {
                         #access-overlay {
-                            justify-content: flex-start;
                             padding-top: 1em;
                         }
                     }
@@ -2276,10 +2270,10 @@
 		</style>
 	</head>
         <body
-                class="text-white min-h-screen flex flex-col overflow-x-hidden overflow-y-auto scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-[\#00FF7E]"
+                class="text-white min-h-screen flex flex-col overflow-x-hidden overflow-y-auto scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-[\#00FF00]"
         >
                 <div id="access-overlay">
-                        <canvas id="q-hero" class="q-hero-canvas"></canvas>
+                        <canvas id="qCanvas" class="q-hero-canvas" width="600" height="600"></canvas>
                         <div class="center-content">
                                   <div class="branding sixtyfour-font">QUANTUMI</div>
                         </div>
@@ -2295,182 +2289,131 @@
                                 <p id="overlay-description">QuantumI visually standardizes and logs blockchain transactions, simplifying crypto analytics for everyone.</p>
                                 <div id="access-error" class="hidden"></div>
                         </form>
-                        <div class="buttons">
-                                <button class="btn" id="layer1" onclick="setLayer(0)">Layer I</button>
-                                <button class="btn selected" id="layer2" onclick="setLayer(1)">Layer II</button>
-                                <button class="btn" id="layer3" onclick="setLayer(2)">Layer III</button>
+                                <div class="buttons">
+                                <button class="btn layer-btn" id="btn0" onclick="setLayer(0)">Layer I</button>
+                                <button class="btn layer-btn selected" id="btn1" onclick="setLayer(1)">Layer II</button>
+                                <button class="btn layer-btn" id="btn2" onclick="setLayer(2)">Layer III</button>
                         </div>
-                </div>
+                  </div>
                 <script>
-                        const Q_GRID = [
-                                [0,1,1,1,1,1,1,1,0].reverse(),
-                                [1,1,0,0,0,0,0,1,1].reverse(),
-                                [1,0,1,1,1,1,1,0,1].reverse(),
-                                [1,0,1,0,0,0,1,0,1].reverse(),
-                                [1,0,1,0,0,0,1,0,1].reverse(),
-                                [1,0,1,0,0,0,1,0,1].reverse(),
-                                [1,0,1,1,1,1,1,0,1].reverse(),
-                                [1,1,0,0,0,1,0,1,1].reverse(),
-                                [0,1,1,1,1,0,1,1,0].reverse(),
-                                [0,0,0,0,1,1,1,0,0].reverse(),
-                                [0,0,0,0,0,1,0,0,0].reverse()
-                        ];
-                        const GRID_COLS = Q_GRID[0].length;
-                        const GRID_ROWS = Q_GRID.length;
+    // Updated layout with 6 columns, third column removed
+    const Q_LAYOUT = [
+      { row: 0, cols: [1, 2, 3, 4] },
+      { row: 1, cols: [0, 5] },
+      { row: 2, cols: [0, 5] },
+      { row: 3, cols: [0, 5] },
+      { row: 4, cols: [0, 5] },
+      { row: 5, cols: [1, 2, 3] },
+      { row: 6, cols: [4] }
+    ];
 
-                        const LAYER_CONFIG = [
-                                {subX: 1, subY: 1, dotRadius: 0.32},
-                                {subX: 3, subY: 2, dotRadius: 0.13},
-                                {subX: 4, subY: 3, dotRadius: 0.092}
-                        ];
-                        let currentLayer = 1;
+    const layers = [
+      { spacing: 1.0, radius: 0.14 },
+      { spacing: 0.5, radius: 0.14 },
+      { spacing: 0.3, radius: 0.14 }
+    ];
 
-                        const canvas = document.getElementById('q-hero');
-                        const ctx = canvas.getContext('2d');
-                        let W = 0, H = 0, CELL = 0, X0 = 0, Y0 = 0;
+    const canvas = document.getElementById("qCanvas");
+    const ctx = canvas.getContext("2d");
+    const ROWS = 7;
+    const COLS = 6;
+    let dots = [];
+    let currentLayer = 1;
 
-                        function resize() {
-                                W = canvas.offsetWidth;
-                                H = Math.max(canvas.offsetHeight * 0.55, 320);
-                                canvas.width = W * window.devicePixelRatio;
-                                canvas.height = H * window.devicePixelRatio;
-                                ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
-                                const margin = 1.4;
-                                CELL = Math.min(W / (GRID_COLS + margin * 2), H / (GRID_ROWS + margin * 2));
-                                X0 = (W - GRID_COLS * CELL) / 2;
-                                Y0 = (H - GRID_ROWS * CELL) / 2;
-                        }
-                        window.addEventListener('resize', resize);
-                        resize();
+    function setLayer(index) {
+      currentLayer = index;
+      document.querySelectorAll(".layer-btn").forEach((btn, i) =>
+        btn.classList.toggle("selected", i === index)
+      );
+      generateDots();
+      requestAnimationFrame(animate);
+    }
 
-                        function getLogoDots(layerIdx) {
-                                const config = LAYER_CONFIG[layerIdx];
-                                let dots = [];
-                                for (let y = 0; y < GRID_ROWS; y++) {
-                                        for (let x = 0; x < GRID_COLS; x++) {
-                                                if (Q_GRID[y][x]) {
-                                                        for (let iy = 0; iy < config.subY; iy++) {
-                                                                for (let ix = 0; ix < config.subX; ix++) {
-                                                                        const offsetX = (ix - (config.subX - 1) / 2) / config.subX;
-                                                                        const offsetY = (iy - (config.subY - 1) / 2) / config.subY;
-                                                                        dots.push({x, y, offsetX, offsetY});
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                                return dots;
-                        }
+    function generateDots() {
+      const spacing = layers[currentLayer].spacing;
+      const cellSize = Math.min(canvas.width / (COLS + 2), canvas.height / (ROWS + 2));
+      const offsetX = (canvas.width - COLS * cellSize) / 2;
+      const offsetY = (canvas.height - ROWS * cellSize) / 2;
+      const dotWidth = cellSize * 0.4;
+      const dotHeight = cellSize * 0.2;
+      const dotRadius = cellSize * 0.1;
+      dots = [];
 
-                        function getRandomScatterPos() {
-                                return {
-                                        x: Math.random() * (GRID_COLS + 2) - 1,
-                                        y: Math.random() * (GRID_ROWS + 2) - 1
-                                };
-                        }
+      for (let item of Q_LAYOUT) {
+        let y = item.row;
+        for (let x of item.cols) {
+          const baseX = offsetX + x * cellSize + cellSize / 2;
+          const baseY = offsetY + y * cellSize + cellSize / 2;
+          const count = Math.floor(1 / spacing);
 
-                        let dots = [];
-                        let isHovering = false;
-                        let startTime = null;
-                        let animating = false;
+          for (let i = 0; i <= count; i++) {
+            const dx = (i - count / 2) * spacing * cellSize;
+            dots.push({
+              x: Math.random() * canvas.width,
+              y: Math.random() * canvas.height,
+              tx: baseX + dx,
+              ty: baseY,
+              width: dotWidth,
+              height: dotHeight,
+              radius: dotRadius,
+              alpha: 0,
+              start: performance.now() + Math.random() * 300
+            });
+          }
+        }
+      }
+    }
 
-                        function initDots(assemble) {
-                                const logoDots = getLogoDots(currentLayer);
-                                dots = [];
-                                const totalPixels = logoDots.length;
-                                let scatterPositions = [];
-                                for (let i = 0; i < totalPixels; i++) {
-                                        scatterPositions.push(getRandomScatterPos());
-                                }
-                                for (let i = 0; i < totalPixels; i++) {
-                                        const target = logoDots[i];
-                                        const delay = Math.random() * 0.18;
-                                        dots.push({
-                                                from: assemble ? scatterPositions[i] : target,
-                                                to: assemble ? target : scatterPositions[i],
-                                                progress: 0,
-                                                delay: delay
-                                        });
-                                }
-                        }
+    function drawRoundedRect(x, y, width, height, radius) {
+      ctx.beginPath();
+      ctx.moveTo(x + radius, y);
+      ctx.lineTo(x + width - radius, y);
+      ctx.arcTo(x + width, y, x + width, y + radius, radius);
+      ctx.lineTo(x + width, y + height - radius);
+      ctx.arcTo(x + width, y + height, x + width - radius, y + height, radius);
+      ctx.lineTo(x + radius, y + height);
+      ctx.arcTo(x, y + height, x, y + height - radius, radius);
+      ctx.lineTo(x, y + radius);
+      ctx.arcTo(x, y, x + radius, y, radius);
+      ctx.closePath();
+      ctx.fill();
+    }
 
-                        function drawLogoDots(progress) {
-                                ctx.clearRect(0, 0, canvas.width, canvas.height);
-                                const config = LAYER_CONFIG[currentLayer];
-                                for (let i = 0; i < dots.length; i++) {
-                                        let d = dots[i];
-                                        let t = Math.max(0, Math.min(1, (progress - d.delay) / 1.3));
-                                        t = t < 1 ? 1 - Math.pow(1 - t, 2.5) : 1;
-                                        d.progress = t;
+    function animate(now) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      let complete = true;
 
-                                        let x = d.from.x + (d.to.x - d.from.x) * t;
-                                        let y = d.from.y + (d.to.y - d.from.y) * t;
-                                        let cx = X0 + (x + 0.5 + (d.to.offsetX || 0)) * CELL;
-                                        let cy = Y0 + (y + 0.5 + (d.to.offsetY || 0)) * CELL;
+      for (let dot of dots) {
+        let elapsed = now - dot.start;
+        if (elapsed < 0) {
+          complete = false;
+          continue;
+        }
+        const t = Math.min(1, elapsed / 800);
+        const ease = 1 - Math.pow(1 - t, 3);
 
-                                        ctx.save();
-                                        ctx.beginPath();
-                                        ctx.arc(cx, cy, CELL * config.dotRadius, 0, 2 * Math.PI);
-                                        ctx.fillStyle = "#e3e3e3";
-                                        ctx.shadowColor = "#fff";
-                                        ctx.shadowBlur = 10;
-                                        ctx.globalAlpha = 0.97;
-                                        ctx.fill();
-                                        ctx.restore();
-                                }
-                        }
+      const cx = dot.x + (dot.tx - dot.x) * ease;
+      const cy = dot.y + (dot.ty - dot.y) * ease;
 
-                        function animateLogo(ts) {
-                                if (!startTime) startTime = ts;
-                                const elapsed = (ts - startTime) / 1000;
-                                drawLogoDots(elapsed);
-                                if (elapsed < 1.5) {
-                                        animating = true;
-                                        requestAnimationFrame(animateLogo);
-                                } else if (!isHovering) {
-                                        drawLogoDots(1.5);
-                                        animating = false;
-                                }
-                        }
+        ctx.fillStyle = `rgba(227,227,227,${ease})`;
+        ctx.shadowColor = "#fff";
+        ctx.shadowBlur = 12;
+        drawRoundedRect(cx - dot.width / 2, cy - dot.height / 2, dot.width, dot.height, dot.radius);
 
-                        function setLayer(idx) {
-                                if (currentLayer === idx) return;
-                                currentLayer = idx;
-                                document.querySelectorAll('.btn').forEach((b, i) => {
-                                        b.classList.toggle('selected', i === idx);
-                                });
-                                startTime = null;
-                                initDots(isHovering);
-                                animating = true;
-                                requestAnimationFrame(animateLogo);
-                        }
+        if (t < 1) complete = false;
+      }
 
-                        canvas.addEventListener('click', () => {
-                                setLayer((currentLayer + 1) % LAYER_CONFIG.length);
-                        });
+      if (!complete) requestAnimationFrame(animate);
+    }
 
-                        canvas.addEventListener('mouseover', () => {
-                                if (!isHovering && !animating) {
-                                        isHovering = true;
-                                        startTime = null;
-                                        initDots(true);
-                                        requestAnimationFrame(animateLogo);
-                                }
-                        });
+    canvas.addEventListener('click', () => {
+      setLayer((currentLayer + 1) % layers.length);
+    });
 
-                        canvas.addEventListener('mouseout', () => {
-                                if (isHovering && !animating) {
-                                        isHovering = false;
-                                        startTime = null;
-                                        initDots(false);
-                                        requestAnimationFrame(animateLogo);
-                                }
-                        });
-
-                        initDots(false);
-                        setLayer(1); // Default to Layer II
+    generateDots();
+    requestAnimationFrame(animate);
                 </script>
-		<button
+                  <button
 			aria-label="Toggle navigation menu"
 			class="nav-menu-toggle hidden"
 			id="nav-menu-toggle"
@@ -3819,9 +3762,9 @@
 				bitcrusherNode,
 				gainNode;
                         const themes = {
-                                original: ['#00FF7E', '#00cc5b', '#009944', '#e0f7fa'],
-                                heatmap: ['#66ff66', '#ffff00', '#ff0000'],
-                                lifecycle: ['#003a1c', '#00cc5b', '#00FF7E']
+original: ['#00FF00', '#00cc00', '#009900', '#e0ffe0'],
+heatmap: ['#66ff66', '#ffff00', '#ff0000'],
+lifecycle: ['#003a00', '#00cc00', '#00FF00']
                         };
                         let currentTheme = 'heatmap';
 			let siteColors = themes.original;
@@ -4631,7 +4574,7 @@ function setupModuleToggles() {
 
                                 const initWidget = () => {
                                         const style = getComputedStyle(document.documentElement);
-                                        const upColor = style.getPropertyValue('--primary-color').trim() || '#00FF7E';
+                                        const upColor = style.getPropertyValue('--primary-color').trim() || '#00FF00';
                                         const downColor = '#ff0000';
                                         try {
                                                 const widget = new TradingView.widget({
@@ -5634,10 +5577,10 @@ function setupModuleToggles() {
                                                                 label: '24h Price Change (%)',
                                                                 data: data,
                                                                 backgroundColor: data.map((value) =>
-                                                                        value >= 0 ? '#00FF7E' : '#FF0000'
+                                                                        value >= 0 ? '#00FF00' : '#FF0000'
                                                                 ),
                                                                 borderColor: data.map((value) =>
-                                                                        value >= 0 ? '#00FF7E' : '#FF0000'
+                                                                        value >= 0 ? '#00FF00' : '#FF0000'
                                                                 ),
                                                                 borderWidth: 1
                                                         }
@@ -7345,7 +7288,7 @@ function setupModuleToggles() {
 
                                 const labels = filteredTokens.map((t) => t.symbol.toUpperCase());
                                 const data = filteredTokens.map((t) => t.price_change_percentage_24h);
-                                const green = '#2ecc71';
+                                const green = '#00FF00';
                                 const red = '#e74c3c';
                                 const bgColor = data.map((change) => (change >= 0 ? green : red));
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -31,7 +31,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       padding: clamp(1.5em, 5vh, 3em) 1em;
       padding-bottom: calc(env(safe-area-inset-bottom) + clamp(1.5em, 5vh, 3em));
       box-sizing: border-box;
@@ -106,7 +106,7 @@
     }
     .login-btn:hover,
     .login-btn:focus {
-      background: #35e1ad;
+      background: #00FF00;
       color: #111;
     }
     .buttons {
@@ -130,13 +130,13 @@
       outline: none;
     }
     .btn.selected {
-      background: rgba(0,255,126,0.3);
+      background: rgba(0,255,0,0.3);
       color: #fff;
-      border-color: rgba(0,255,126,0.4);
+      border-color: rgba(0,255,0,0.4);
     }
     .btn:hover:not(.selected),
     .btn:focus:not(.selected) {
-      background: rgba(0,255,126,0.2);
+      background: rgba(0,255,0,0.2);
       color: #fff;
       transform: scale(1.04);
     }
@@ -163,7 +163,6 @@
     }
     @media (max-height: 700px) {
       main {
-        justify-content: flex-start;
         padding-top: 1em;
       }
       .q-hero-canvas {
@@ -177,7 +176,7 @@
 </head>
 <body>
   <main>
-    <canvas id="q-hero" class="q-hero-canvas"></canvas>
+    <canvas id="qCanvas" class="q-hero-canvas" width="600" height="600"></canvas>
     <div class="center-content">
       <div class="branding sixtyfour-font">QUANTUMI</div>
     </div>
@@ -187,195 +186,132 @@
       <button class="login-btn" type="submit">Sign In</button>
     </form>
     <div class="buttons">
-      <button class="btn" id="layer1" onclick="setLayer(0)">Layer I</button>
-      <button class="btn selected" id="layer2" onclick="setLayer(1)">Layer II</button>
-      <button class="btn" id="layer3" onclick="setLayer(2)">Layer III</button>
+      <button class="btn layer-btn" onclick="setLayer(0)" id="btn0">Layer I</button>
+      <button class="btn layer-btn selected" onclick="setLayer(1)" id="btn1">Layer II</button>
+      <button class="btn layer-btn" onclick="setLayer(2)" id="btn2">Layer III</button>
     </div>
   </main>
   <footer>
     &copy; 2025 <span class="sixtyfour-font">QUANTUMI</span> &mdash; All Rights Reserved.
   </footer>
   <script>
-    const Q_GRID = [
-      [0,1,1,1,1,1,1,1,0].reverse(),
-      [1,1,0,0,0,0,0,1,1].reverse(),
-      [1,0,1,1,1,1,1,0,1].reverse(),
-      [1,0,1,0,0,0,1,0,1].reverse(),
-      [1,0,1,0,0,0,1,0,1].reverse(),
-      [1,0,1,0,0,0,1,0,1].reverse(),
-      [1,0,1,1,1,1,1,0,1].reverse(),
-      [1,1,0,0,0,1,0,1,1].reverse(),
-      [0,1,1,1,1,0,1,1,0].reverse(),
-      [0,0,0,0,1,1,1,0,0].reverse(),
-      [0,0,0,0,0,1,0,0,0].reverse()
+    // Updated layout with 6 columns, third column removed
+    const Q_LAYOUT = [
+      { row: 0, cols: [1, 2, 3, 4] },
+      { row: 1, cols: [0, 5] },
+      { row: 2, cols: [0, 5] },
+      { row: 3, cols: [0, 5] },
+      { row: 4, cols: [0, 5] },
+      { row: 5, cols: [1, 2, 3] },
+      { row: 6, cols: [4] }
     ];
-    const GRID_COLS = Q_GRID[0].length;
-    const GRID_ROWS = Q_GRID.length;
 
-    const LAYER_CONFIG = [
-      {subX: 1, subY: 1, dotRadius: 0.32},
-      {subX: 3, subY: 2, dotRadius: 0.13},
-      {subX: 4, subY: 3, dotRadius: 0.092}
+    const layers = [
+      { spacing: 1.0, radius: 0.14 },
+      { spacing: 0.5, radius: 0.14 },
+      { spacing: 0.3, radius: 0.14 }
     ];
+
+    const canvas = document.getElementById("qCanvas");
+    const ctx = canvas.getContext("2d");
+    const ROWS = 7;
+    const COLS = 6;
+    let dots = [];
     let currentLayer = 1;
-    const LAYER = {...LAYER_CONFIG[currentLayer]};
 
-    const canvas = document.getElementById('q-hero');
-    const ctx = canvas.getContext('2d');
-    let W = 0, H = 0, CELL = 0, X0 = 0, Y0 = 0;
-    let currentProgress = 0;
-    let mouseOffsetX = 0, mouseOffsetY = 0;
-
-    function resize() {
-      W = canvas.offsetWidth;
-      H = canvas.offsetHeight;
-      canvas.width = W * window.devicePixelRatio;
-      canvas.height = H * window.devicePixelRatio;
-      ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
-      const margin = 1.4;
-      CELL = Math.min(W / (GRID_COLS + margin * 2), H / (GRID_ROWS + margin * 2));
-      X0 = (W - GRID_COLS * CELL) / 2;
-      Y0 = (H - GRID_ROWS * CELL) / 2;
+    function setLayer(index) {
+      currentLayer = index;
+      document.querySelectorAll(".layer-btn").forEach((btn, i) =>
+        btn.classList.toggle("selected", i === index)
+      );
+      generateDots();
+      requestAnimationFrame(animate);
     }
-    window.addEventListener('resize', resize);
-    resize();
 
-    function getLogoDots() {
-      const config = LAYER;
-      let dots = [];
-      for (let y = 0; y < GRID_ROWS; y++) {
-        for (let x = 0; x < GRID_COLS; x++) {
-          if (Q_GRID[y][x]) {
-            for (let iy = 0; iy < config.subY; iy++) {
-              for (let ix = 0; ix < config.subX; ix++) {
-                const offsetX = (ix - (config.subX - 1) / 2) / config.subX;
-                const offsetY = (iy - (config.subY - 1) / 2) / config.subY;
-                dots.push({x, y, offsetX, offsetY});
-              }
-            }
+    function generateDots() {
+      const spacing = layers[currentLayer].spacing;
+      const cellSize = Math.min(canvas.width / (COLS + 2), canvas.height / (ROWS + 2));
+      const offsetX = (canvas.width - COLS * cellSize) / 2;
+      const offsetY = (canvas.height - ROWS * cellSize) / 2;
+      const dotWidth = cellSize * 0.4;
+      const dotHeight = cellSize * 0.2;
+      const dotRadius = cellSize * 0.1;
+      dots = [];
+
+      for (let item of Q_LAYOUT) {
+        let y = item.row;
+        for (let x of item.cols) {
+          const baseX = offsetX + x * cellSize + cellSize / 2;
+          const baseY = offsetY + y * cellSize + cellSize / 2;
+          const count = Math.floor(1 / spacing);
+
+          for (let i = 0; i <= count; i++) {
+            const dx = (i - count / 2) * spacing * cellSize;
+            dots.push({
+              x: Math.random() * canvas.width,
+              y: Math.random() * canvas.height,
+              tx: baseX + dx,
+              ty: baseY,
+              width: dotWidth,
+              height: dotHeight,
+              radius: dotRadius,
+              alpha: 0,
+              start: performance.now() + Math.random() * 300
+            });
           }
         }
       }
-      return dots;
     }
 
-    function getRandomScatterPos() {
-      return {
-        x: Math.random() * (GRID_COLS + 2) - 1,
-        y: Math.random() * (GRID_ROWS + 2) - 1
-      };
+    function drawRoundedRect(x, y, width, height, radius) {
+      ctx.beginPath();
+      ctx.moveTo(x + radius, y);
+      ctx.lineTo(x + width - radius, y);
+      ctx.arcTo(x + width, y, x + width, y + radius, radius);
+      ctx.lineTo(x + width, y + height - radius);
+      ctx.arcTo(x + width, y + height, x + width - radius, y + height, radius);
+      ctx.lineTo(x + radius, y + height);
+      ctx.arcTo(x, y + height, x, y + height - radius, radius);
+      ctx.lineTo(x, y + radius);
+      ctx.arcTo(x, y, x + radius, y, radius);
+      ctx.closePath();
+      ctx.fill();
     }
 
-    let dots = [];
-    let isHovering = false;
-    let startTime = null;
-    let animating = false;
-
-    function initDots(assemble) {
-      const logoDots = getLogoDots();
-      dots = [];
-      const totalPixels = logoDots.length;
-      let scatterPositions = [];
-      for (let i = 0; i < totalPixels; i++) {
-        scatterPositions.push(getRandomScatterPos());
-      }
-      for (let i = 0; i < totalPixels; i++) {
-        const target = logoDots[i];
-        const delay = Math.random() * 0.18;
-        dots.push({
-          from: assemble ? scatterPositions[i] : target,
-          to: assemble ? target : scatterPositions[i],
-          progress: 0,
-          delay: delay
-        });
-      }
-    }
-
-    function drawLogoDots(progress) {
-      currentProgress = progress;
+    function animate(now) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const config = LAYER;
-      for (let i = 0; i < dots.length; i++) {
-        let d = dots[i];
-        let t = Math.max(0, Math.min(1, (progress - d.delay) / 1.3));
-        t = t < 1 ? 1 - Math.pow(1 - t, 2.5) : 1;
-        d.progress = t;
+      ctx.shadowColor = currentLayer === 2 ? "#fff" : "transparent";
+      ctx.shadowBlur = currentLayer === 2 ? 12 : 0;
+      let complete = true;
 
-        let x = d.from.x + (d.to.x - d.from.x) * t;
-        let y = d.from.y + (d.to.y - d.from.y) * t;
-        let cx = X0 + (x + 0.5 + (d.to.offsetX || 0)) * CELL + mouseOffsetX * 20;
-        let cy = Y0 + (y + 0.5 + (d.to.offsetY || 0)) * CELL + mouseOffsetY * 20;
+      for (let dot of dots) {
+        let elapsed = now - dot.start;
+        if (elapsed < 0) {
+          complete = false;
+          continue;
+        }
+        const t = Math.min(1, elapsed / 800);
+        const ease = 1 - Math.pow(1 - t, 3);
 
-        ctx.save();
-        ctx.beginPath();
-        ctx.arc(cx, cy, CELL * config.dotRadius, 0, 2 * Math.PI);
-        ctx.fillStyle = "#e3e3e3";
-        ctx.shadowColor = "#fff";
-        ctx.shadowBlur = 10;
-        ctx.globalAlpha = 0.97;
-        ctx.fill();
-        ctx.restore();
+        const cx = dot.x + (dot.tx - dot.x) * ease;
+        const cy = dot.y + (dot.ty - dot.y) * ease;
+
+        ctx.fillStyle = `rgba(227,227,227,${ease})`;
+        drawRoundedRect(cx - dot.width / 2, cy - dot.height / 2, dot.width, dot.height, dot.radius);
+
+        if (t < 1) complete = false;
       }
-    }
 
-    function animateLogo(ts) {
-      if (!startTime) startTime = ts;
-      const elapsed = (ts - startTime) / 1000;
-      drawLogoDots(elapsed);
-      if (elapsed < 1.5) {
-        animating = true;
-        requestAnimationFrame(animateLogo);
-      } else if (!isHovering) {
-        drawLogoDots(1.5);
-        animating = false;
-      }
-    }
-
-    canvas.addEventListener('mouseover', () => {
-      if (!isHovering && !animating) {
-        isHovering = true;
-        startTime = null;
-        initDots(true);
-        requestAnimationFrame(animateLogo);
-      }
-    });
-
-    canvas.addEventListener('mouseout', () => {
-      if (isHovering && !animating) {
-        isHovering = false;
-        startTime = null;
-        initDots(false);
-        requestAnimationFrame(animateLogo);
-      }
-    });
-
-    canvas.addEventListener('mousemove', (e) => {
-      const rect = canvas.getBoundingClientRect();
-      mouseOffsetX = (e.clientX - rect.left - rect.width / 2) / rect.width;
-      mouseOffsetY = (e.clientY - rect.top - rect.height / 2) / rect.height;
-      if (!animating) drawLogoDots(currentProgress);
-    });
-
-    initDots(false);
-    drawLogoDots(0);
-
-    function setLayer(idx) {
-      if (currentLayer === idx) return;
-      currentLayer = idx;
-      document.querySelectorAll('.btn').forEach((b, i) => {
-        b.classList.toggle('selected', i === idx);
-      });
-      Object.assign(LAYER, LAYER_CONFIG[idx]);
-      startTime = null;
-      initDots(isHovering);
-      animating = true;
-      requestAnimationFrame(animateLogo);
+      if (!complete) requestAnimationFrame(animate);
     }
 
     canvas.addEventListener('click', () => {
-      setLayer((currentLayer + 1) % LAYER_CONFIG.length);
+      setLayer((currentLayer + 1) % layers.length);
     });
 
+    // Init
+    generateDots();
+    requestAnimationFrame(animate);
   </script>
 </body>
 </html>

--- a/frontend/logo-embed.html
+++ b/frontend/logo-embed.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Q Tube Logo Layer II</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    html, body {
+      margin: 0;
+      background: #111215;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      flex-direction: column;
+      color: #e3e3e3;
+      font-family: sans-serif;
+    }
+    canvas {
+      background: #000;
+      border-radius: 16px;
+      box-shadow: 0 0 24px #000b;
+      width: 80vmin;
+      height: 80vmin;
+    }
+    a {
+      margin-top: 1rem;
+      color: #00FF00;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="qCanvas" width="600" height="600"></canvas>
+  <a id="download" href="#" download="layer2-logo.png">Download PNG</a>
+  <script>
+    const Q_LAYOUT = [
+      { row: 0, cols: [1, 2, 3, 4] },
+      { row: 1, cols: [0, 5] },
+      { row: 2, cols: [0, 5] },
+      { row: 3, cols: [0, 5] },
+      { row: 4, cols: [0, 5] },
+      { row: 5, cols: [1, 2, 3] },
+      { row: 6, cols: [4] }
+    ];
+    const layers = [
+      { spacing: 1.0, radius: 0.14 },
+      { spacing: 0.5, radius: 0.14 },
+      { spacing: 0.3, radius: 0.14 }
+    ];
+    const canvas = document.getElementById('qCanvas');
+    const ctx = canvas.getContext('2d');
+    const ROWS = 7;
+    const COLS = 6;
+    let dots = [];
+    let currentLayer = 1;
+
+    function generateDots() {
+      const spacing = layers[currentLayer].spacing;
+      const cellSize = Math.min(canvas.width / (COLS + 2), canvas.height / (ROWS + 2));
+      const offsetX = (canvas.width - COLS * cellSize) / 2;
+      const offsetY = (canvas.height - ROWS * cellSize) / 2;
+      const dotWidth = cellSize * 0.4;
+      const dotHeight = cellSize * 0.2;
+      const dotRadius = cellSize * 0.1;
+      dots = [];
+      for (let item of Q_LAYOUT) {
+        let y = item.row;
+        for (let x of item.cols) {
+          const baseX = offsetX + x * cellSize + cellSize / 2;
+          const baseY = offsetY + y * cellSize + cellSize / 2;
+          const count = Math.floor(1 / spacing);
+          for (let i = 0; i <= count; i++) {
+            const dx = (i - count / 2) * spacing * cellSize;
+            dots.push({
+              x: Math.random() * canvas.width,
+              y: Math.random() * canvas.height,
+              tx: baseX + dx,
+              ty: baseY,
+              width: dotWidth,
+              height: dotHeight,
+              radius: dotRadius,
+              alpha: 0,
+              start: performance.now() + Math.random() * 300
+            });
+          }
+        }
+      }
+    }
+    function drawRoundedRect(x, y, width, height, radius) {
+      ctx.beginPath();
+      ctx.moveTo(x + radius, y);
+      ctx.lineTo(x + width - radius, y);
+      ctx.arcTo(x + width, y, x + width, y + radius, radius);
+      ctx.lineTo(x + width, y + height - radius);
+      ctx.arcTo(x + width, y + height, x + width - radius, y + height, radius);
+      ctx.lineTo(x + radius, y + height);
+      ctx.arcTo(x, y + height, x, y + height - radius, radius);
+      ctx.lineTo(x, y + radius);
+      ctx.arcTo(x, y, x + radius, y, radius);
+      ctx.closePath();
+      ctx.fill();
+    }
+    function animate(now) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      let complete = true;
+      for (let dot of dots) {
+        let elapsed = now - dot.start;
+        if (elapsed < 0) { complete = false; continue; }
+        const t = Math.min(1, elapsed / 800);
+        const ease = 1 - Math.pow(1 - t, 3);
+        const cx = dot.x + (dot.tx - dot.x) * ease;
+        const cy = dot.y + (dot.ty - dot.y) * ease;
+        ctx.fillStyle = `rgba(227,227,227,${ease})`;
+        ctx.shadowColor = '#fff';
+        ctx.shadowBlur = 12;
+        drawRoundedRect(cx - dot.width / 2, cy - dot.height / 2, dot.width, dot.height, dot.radius);
+        if (t < 1) complete = false;
+      }
+      if (!complete) {
+        requestAnimationFrame(animate);
+      } else {
+        document.getElementById('download').href = canvas.toDataURL('image/png');
+      }
+    }
+    generateDots();
+    requestAnimationFrame(animate);
+  </script>
+</body>
+</html>

--- a/frontend/quantumi-logo.js
+++ b/frontend/quantumi-logo.js
@@ -1,44 +1,63 @@
 (function(){
-  const RAW_Q_GRID = [
-    [0,1,1,1,1,1,1,1,0],
-    [1,1,0,0,0,0,0,1,1],
-    [1,0,1,1,1,1,1,0,1],
-    [1,0,1,0,0,0,1,0,1],
-    [1,0,1,0,0,0,1,0,1],
-    [1,0,1,0,0,0,1,0,1],
-    [1,0,1,1,1,1,1,0,1],
-    [1,1,0,0,0,1,0,1,1],
-    [0,1,1,1,1,0,1,1,0],
-    [0,0,0,0,1,1,1,0,0],
-    [0,0,0,0,0,1,0,0,0]
+  const Q_LAYOUT = [
+    { row: 0, cols: [1, 2, 3, 4] },
+    { row: 1, cols: [0, 5] },
+    { row: 2, cols: [0, 5] },
+    { row: 3, cols: [0, 5] },
+    { row: 4, cols: [0, 5] },
+    { row: 5, cols: [1, 2, 3] },
+    { row: 6, cols: [4] }
   ];
-  const Q_GRID = RAW_Q_GRID.map(r => r.slice().reverse());
-  const GRID_COLS = Q_GRID[0].length, GRID_ROWS = Q_GRID.length;
-  const config = {subX:4, subY:3, dotRadius:0.092};
+  const LAYER = { spacing: 0.5, radius: 0.14 }; // Layer II
+  const ROWS = 7;
+  const COLS = 6;
+
+  function drawRoundedRect(ctx, x, y, width, height, radius) {
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + width - radius, y);
+    ctx.arcTo(x + width, y, x + width, y + radius, radius);
+    ctx.lineTo(x + width, y + height - radius);
+    ctx.arcTo(x + width, y + height, x + width - radius, y + height, radius);
+    ctx.lineTo(x + radius, y + height);
+    ctx.arcTo(x, y + height, x, y + height - radius, radius);
+    ctx.lineTo(x, y + radius);
+    ctx.arcTo(x, y, x + radius, y, radius);
+    ctx.closePath();
+    ctx.fill();
+  }
+
   function drawLogo(ctx, w, h){
     ctx.clearRect(0,0,w,h);
-    const margin = 1.4;
-    const cell = Math.min(w/(GRID_COLS+margin*2), h/(GRID_ROWS+margin*2));
-    const X0 = (w - GRID_COLS*cell)/2;
-    const Y0 = (h - GRID_ROWS*cell)/2;
-    for(let y=0;y<GRID_ROWS;y++) for(let x=0;x<GRID_COLS;x++) if(Q_GRID[y][x]){
-      for(let iy=0; iy<config.subY; iy++) for(let ix=0; ix<config.subX; ix++){
-        const offsetX = (ix - (config.subX-1)/2)/config.subX;
-        const offsetY = (iy - (config.subY-1)/2)/config.subY;
-        let cx = X0 + (x+0.5+offsetX)*cell;
-        let cy = Y0 + (y+0.5+offsetY)*cell;
-        ctx.save();
-        ctx.beginPath();
-        ctx.arc(cx, cy, cell*config.dotRadius, 0, 2*Math.PI);
-        ctx.fillStyle = '#e3e3e3';
-        ctx.shadowColor = '#fff';
-        ctx.shadowBlur = 6;
-        ctx.globalAlpha = 1;
-        ctx.fill();
-        ctx.restore();
+    const spacing = LAYER.spacing;
+    const cellSize = Math.min(w/(COLS+2), h/(ROWS+2));
+    const offsetX = (w - COLS*cellSize)/2;
+    const offsetY = (h - ROWS*cellSize)/2;
+    const dotWidth = cellSize*0.4;
+    const dotHeight = cellSize*0.2;
+    const dotRadius = cellSize*0.1;
+    ctx.fillStyle = '#e3e3e3';
+    ctx.shadowColor = '#fff';
+    ctx.shadowBlur = 6;
+    for (let item of Q_LAYOUT) {
+      let y = item.row;
+      for (let x of item.cols) {
+        const baseX = offsetX + x*cellSize + cellSize/2;
+        const baseY = offsetY + y*cellSize + cellSize/2;
+        const count = Math.floor(1/spacing);
+        for (let i=0;i<=count;i++){
+          const dx = (i - count/2)*spacing*cellSize;
+          drawRoundedRect(ctx,
+            baseX + dx - dotWidth/2,
+            baseY - dotHeight/2,
+            dotWidth,
+            dotHeight,
+            dotRadius);
+        }
       }
     }
   }
+
   function render(canvas){
     const rect = canvas.getBoundingClientRect();
     canvas.width = rect.width;
@@ -46,9 +65,11 @@
     const ctx = canvas.getContext('2d');
     drawLogo(ctx, canvas.width, canvas.height);
   }
+
   function init(){
     document.querySelectorAll('canvas.quantumi-logo').forEach(render);
   }
+
   window.addEventListener('resize', init);
   document.addEventListener('DOMContentLoaded', init);
 })();

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -385,7 +385,7 @@ function updateChart(symbol) {
       studies: ['Volume@tv-basicstudies'],
       overrides: {
         "paneProperties.background": "#0a0f14",
-        "mainSeriesProperties.candleStyle.upColor": "#00ff00",
+        "mainSeriesProperties.candleStyle.upColor": "#00FF00",
         "mainSeriesProperties.candleStyle.downColor": "#ff0000"
       }
     });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -79,7 +79,7 @@ canvas {
 
 .glow-blue,
 .glow-purple {
-  box-shadow: 0 0 10px rgba(0, 255, 126, 0.3);
+  box-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
 }
 
 .fade-in {
@@ -105,7 +105,7 @@ button {
 button:hover,
 button:focus,
 button:active {
-  background: #00ff7e;
+  background: #00FF00;
   color: #000;
 }
 

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,7 +1,7 @@
 :root {
-  --green-light: #E0FFE8;
-  --green: #00FF7E;
-  --green-dark: #00CC65;
+  --green-light: #E0FFE0;
+  --green: #00FF00;
+  --green-dark: #00CC00;
   --color-primary: var(--green);
   --color-bg: #0a0a0a;
   --color-bg-alt: #1a1a1a;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,6 +11,12 @@ module.exports = {
         carbon: '#1c1f23',
         accent: '#38bdf8',
         muted: '#64748b',
+        green: {
+          300: '#00FF00',
+          400: '#00FF00',
+          500: '#00FF00',
+          DEFAULT: '#00FF00'
+        },
         brand: {
           light: 'var(--green-light)',
           DEFAULT: 'var(--green)',


### PR DESCRIPTION
## Summary
- align login overlay to prevent logo/button clipping and apply Layer III glow on demand
- default Q Tube logos to Layer II across site and add downloadable embed
- make module toggles transparent by default and glow green when active
- restrict Layer III glow to logo points with a white halo instead of canvas box shadow
- remove remaining green glow from Layer III canvas to keep overlay neutral

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6894a3feb8a0832ab754d0038f031d46