### PR TITLE
feat: update login description toggle and color themes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2294,8 +2294,8 @@
                         </form>
                                 <div class="buttons">
                                 <button class="btn layer-btn" id="btn0" onclick="setLayer(0)">Layer I</button>
-                                <button class="btn layer-btn selected" id="btn1" onclick="setLayer(1)">Layer II</button>
-                                <button class="btn layer-btn" id="btn2" onclick="setLayer(2)">Layer III</button>
+                                <button class="btn layer-btn" id="btn1" onclick="setLayer(1)">Layer II</button>
+                                <button class="btn layer-btn selected" id="btn2" onclick="setLayer(2)">Layer III</button>
                         </div>
                   </div>
                 <script>
@@ -2321,7 +2321,7 @@
     const ROWS = 7;
     const COLS = 6;
     let dots = [];
-    let currentLayer = 1;
+    let currentLayer = 2;
 
     function setLayer(index) {
       currentLayer = index;
@@ -2912,20 +2912,20 @@
 								Gas Heatmap (Multi-Chain)
 							</h3>
 							<canvas id="gas-heatmap-canvas"></canvas>
-							<div id="gas-heatmap-legend">
-								<div class="legend-item">
-                                                                        <div class="legend-color" style="background: var(--primary-color)"></div>
-									<span>Safe</span>
-								</div>
-								<div class="legend-item">
-                                                                        <div class="legend-color" style="background: var(--secondary-color)"></div>
-									<span>Propose</span>
-								</div>
-								<div class="legend-item">
-									<div class="legend-color" style="background: #ff0000"></div>
-									<span>Fast</span>
-								</div>
-							</div>
+                                                        <div id="gas-heatmap-legend">
+                                                                <div class="legend-item">
+                                                                        <div class="legend-color" style="background: #00ff00"></div>
+                                                                        <span>Safe</span>
+                                                                </div>
+                                                                <div class="legend-item">
+                                                                        <div class="legend-color" style="background: #ffff00"></div>
+                                                                        <span>Propose</span>
+                                                                </div>
+                                                                <div class="legend-item">
+                                                                        <div class="legend-color" style="background: #ff0000"></div>
+                                                                        <span>Fast</span>
+                                                                </div>
+                                                        </div>
 							<ul class="space-y-2 text-sm mt-2" id="gas-heatmap-list"></ul>
 						</div>
 						<div>
@@ -3765,9 +3765,9 @@
 				bitcrusherNode,
 				gainNode;
                         const themes = {
-original: ['#00FF00', '#00cc00', '#009900', '#e0ffe0'],
-heatmap: ['#66ff66', '#ffff00', '#ff0000'],
-lifecycle: ['#003a00', '#00cc00', '#00FF00']
+                                original: ['#add8e6', '#7ec8e3', '#55a7d5', '#e0f7ff'],
+                                heatmap: ['#00ff00', '#ffff00', '#ff0000'],
+                                lifecycle: ['#003366', '#0077cc', '#00ccff']
                         };
                         let currentTheme = 'heatmap';
 			let siteColors = themes.original;
@@ -5252,15 +5252,34 @@ function setupModuleToggles() {
 			}
 
                         function updateColorLegend() {
-                                document.getElementById('btc-color-legend').innerHTML = colorLegend
+                                const legend = document.getElementById('btc-color-legend');
+                                if (!legend) return;
+                                let themeLegend = '';
+                                if (currentTheme === 'heatmap') {
+                                        themeLegend = `
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.heatmap[0]}"></div><span>Low</span></div>
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.heatmap[1]}"></div><span>Medium</span></div>
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.heatmap[2]}"></div><span>High</span></div>`;
+                                } else if (currentTheme === 'lifecycle') {
+                                        themeLegend = `
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.lifecycle[0]}"></div><span>New</span></div>
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.lifecycle[1]}"></div><span>Maturing</span></div>
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.lifecycle[2]}"></div><span>Old</span></div>`;
+                                } else {
+                                        themeLegend = `
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.original[0]}"></div><span>Start</span></div>
+        <div class="legend-item"><div class="legend-color" style="background: ${themes.original[themes.original.length - 1]}"></div><span>Fade</span></div>`;
+                                }
+                                const dataLegend = colorLegend
                                         .map(
-                                                (item, index) => `
+                                                (item) => `
         <div class="legend-item" data-tooltip="Price: $${item.price.toLocaleString()}\nVolume: ${item.volume.toLocaleString()}\nTime: ${item.time}">
           <div class="legend-color" style="background: ${item.color}"></div>
         </div>
       `
-					)
+                                        )
                                         .join('');
+                                legend.innerHTML = themeLegend + dataLegend;
                         }
 
                         function interpolateColor(c1, c2, ratio) {
@@ -5361,9 +5380,9 @@ function setupModuleToggles() {
 				});
 
                                 const getColor = (type) => {
-                                        if (type === 'safe') return 'hsl(140, 100%, 25%)';
-                                        if (type === 'propose') return 'hsl(140, 100%, 40%)';
-                                        return 'hsl(140, 100%, 55%)';
+                                        if (type === 'safe') return '#00ff00';
+                                        if (type === 'propose') return '#ffff00';
+                                        return '#ff0000';
                                 };
 
 				const updateHeatmapAndFees = async () => {
@@ -6491,6 +6510,7 @@ function setupModuleToggles() {
 
                                initBtcOverlay();
                                applyTheme(currentTheme);
+                               updateColorLegend();
                                 if (DOM.btcOverlayMode)
                                         DOM.btcOverlayMode.textContent =
                                                 currentTheme === 'heatmap'

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -182,6 +182,8 @@
     <canvas id="qCanvas" class="q-hero-canvas" width="600" height="600"></canvas>
     <div class="center-content">
       <div class="branding sixtyfour-font">QUANTUMI</div>
+      <p id="login-description" class="mt-2 text-sm text-gray-400">Access the QUANTUMI network.</p>
+      <button id="toggle-desc" class="mt-2 text-xs underline">Hide Description</button>
     </div>
     <form class="login-form">
       <input type="text" placeholder="Username or Email" required />
@@ -190,8 +192,8 @@
     </form>
     <div class="buttons">
       <button class="btn layer-btn" onclick="setLayer(0)" id="btn0">Layer I</button>
-      <button class="btn layer-btn selected" onclick="setLayer(1)" id="btn1">Layer II</button>
-      <button class="btn layer-btn" onclick="setLayer(2)" id="btn2">Layer III</button>
+      <button class="btn layer-btn" onclick="setLayer(1)" id="btn1">Layer II</button>
+      <button class="btn layer-btn selected" onclick="setLayer(2)" id="btn2">Layer III</button>
     </div>
   </main>
   <footer>
@@ -220,7 +222,7 @@
     const ROWS = 7;
     const COLS = 6;
     let dots = [];
-    let currentLayer = 1;
+    let currentLayer = 2;
 
     function setLayer(index) {
       currentLayer = index;
@@ -310,6 +312,13 @@
 
     canvas.addEventListener('click', () => {
       setLayer((currentLayer + 1) % layers.length);
+    });
+
+    const desc = document.getElementById('login-description');
+    const toggleDesc = document.getElementById('toggle-desc');
+    toggleDesc.addEventListener('click', () => {
+      const hidden = desc.classList.toggle('hidden');
+      toggleDesc.textContent = hidden ? 'Show Description' : 'Hide Description';
     });
 
     // Init

--- a/frontend/logo-embed.html
+++ b/frontend/logo-embed.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Q Tube Logo Layer II</title>
+  <title>Q Tube Logo Layer III</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <style>
     html, body {
@@ -31,7 +31,7 @@
 </head>
 <body>
   <canvas id="qCanvas" width="600" height="600"></canvas>
-  <a id="download" href="#" download="layer2-logo.png">Download PNG</a>
+  <a id="download" href="#" download="layer3-logo.png">Download PNG</a>
   <script>
     const Q_LAYOUT = [
       { row: 0, cols: [1, 2, 3, 4] },
@@ -52,7 +52,7 @@
     const ROWS = 7;
     const COLS = 6;
     let dots = [];
-    let currentLayer = 1;
+    let currentLayer = 2;
 
     function generateDots() {
       const spacing = layers[currentLayer].spacing;

--- a/frontend/quantumi-logo.js
+++ b/frontend/quantumi-logo.js
@@ -8,7 +8,7 @@
     { row: 5, cols: [1, 2, 3] },
     { row: 6, cols: [4] }
   ];
-  const LAYER = { spacing: 0.5, radius: 0.14 }; // Layer II
+  const LAYER = { spacing: 0.3, radius: 0.14 }; // Layer III
   const ROWS = 7;
   const COLS = 6;
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -181,13 +181,28 @@ async function renderGasHeatmap() {
     const cellWidth = canvas.width / maxHistory;
     const cellHeight = canvas.height;
 
+    const interpolate = (c1, c2, t) => {
+      const toRGB = c => c.match(/\w\w/g).map(x => parseInt(x, 16));
+      const [r1, g1, b1] = toRGB(c1);
+      const [r2, g2, b2] = toRGB(c2);
+      const r = Math.round(r1 + (r2 - r1) * t);
+      const g = Math.round(g1 + (g2 - g1) * t);
+      const b = Math.round(b1 + (b2 - b1) * t);
+      return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+    };
+
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     gasHistory.forEach((data, i) => {
       const ratio = (data.gasPrice - minGas) / (maxGas - minGas || 1);
-      const light = 30 + ratio * 50;
-      ctx.fillStyle = `hsl(140, 100%, ${light}%)`;
+      let color;
+      if (ratio < 0.5) {
+        color = interpolate('#00ff00', '#ffff00', ratio * 2);
+      } else {
+        color = interpolate('#ffff00', '#ff0000', (ratio - 0.5) * 2);
+      }
+      ctx.fillStyle = color;
       ctx.fillRect(i * cellWidth, 0, cellWidth, cellHeight);
-      ctx.strokeStyle = 'rgba(0, 255, 0, 0.2)';
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.2)';
       ctx.strokeRect(i * cellWidth, 0, cellWidth, cellHeight);
     });
 


### PR DESCRIPTION
## Summary
- add optional description toggle on login page and default to Layer III
- introduce blue-based original and lifecycle color themes with legends
- color gas heatmap and legend using green/yellow/red scheme

## Testing
- `npm test` *(fails: Error: no test specified)*
- `(cd frontend && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894d8fb1918832ab506ac9ec68d3a19