### PR TITLE
feat: thicken logo and add login fade-in

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -156,6 +156,14 @@
       border-top: 1px solid #222;
       font-size: 0.95em;
     }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .fade-in {
+      opacity: 0;
+      animation: fadeIn 0.8s ease forwards;
+    }
     @media (max-width: 600px) {
       main {
         padding: 1em 0.3em 2.5em 0.3em;
@@ -182,24 +190,24 @@
 </head>
 <body>
   <main>
-    <canvas id="qCanvas" class="q-hero-canvas" width="600" height="600"></canvas>
+    <canvas id="qCanvas" class="q-hero-canvas fade-in" width="600" height="600" style="animation-delay:0s"></canvas>
     <div class="center-content">
-      <div class="branding sixtyfour-font">QUANTUMI</div>
-      <p id="login-description" class="mt-2 text-sm text-gray-400">Access the QUANTUMI network.</p>
-      <button id="toggle-desc" class="mt-2 text-xs underline">Hide Description</button>
+      <div class="branding sixtyfour-font fade-in" style="animation-delay:0.2s">QUANTUMI</div>
+      <p id="login-description" class="mt-2 text-sm text-gray-400 fade-in" style="animation-delay:0.4s">Access the QUANTUMI network.</p>
+      <button id="toggle-desc" class="mt-2 text-xs underline fade-in" style="animation-delay:0.6s">Hide Description</button>
     </div>
-    <form class="login-form">
+    <form class="login-form fade-in" style="animation-delay:0.8s">
       <input type="text" placeholder="Username or Email" required />
       <input type="password" placeholder="Password" required />
       <button class="login-btn" type="submit">Sign In</button>
     </form>
-    <div class="buttons">
+    <div class="buttons fade-in" style="animation-delay:1s">
       <button class="btn layer-btn" onclick="setLayer(0)" id="btn0">Layer I</button>
       <button class="btn layer-btn" onclick="setLayer(1)" id="btn1">Layer II</button>
       <button class="btn layer-btn selected" onclick="setLayer(2)" id="btn2">Layer III</button>
     </div>
   </main>
-  <footer>
+  <footer class="fade-in" style="animation-delay:1.2s">
     &copy; 2025 <span class="sixtyfour-font">QUANTUMI</span> &mdash; All Rights Reserved.
   </footer>
   <script>
@@ -241,9 +249,9 @@
       const cellSize = Math.min(canvas.width / (COLS + 2), canvas.height / (ROWS + 2));
       const offsetX = (canvas.width - COLS * cellSize) / 2;
       const offsetY = (canvas.height - ROWS * cellSize) / 2;
-      const dotWidth = cellSize * 0.4;
-      const dotHeight = cellSize * 0.2;
-      const dotRadius = cellSize * 0.1;
+      const dotWidth = cellSize * 0.5;
+      const dotHeight = cellSize * 0.3;
+      const dotRadius = cellSize * 0.15;
       dots = [];
 
       for (let item of Q_LAYOUT) {

--- a/frontend/quantumi-logo.js
+++ b/frontend/quantumi-logo.js
@@ -33,9 +33,9 @@
     const cellSize = Math.min(w/(COLS+2), h/(ROWS+2));
     const offsetX = (w - COLS*cellSize)/2;
     const offsetY = (h - ROWS*cellSize)/2;
-    const dotWidth = cellSize*0.4;
-    const dotHeight = cellSize*0.2;
-    const dotRadius = cellSize*0.1;
+    const dotWidth = cellSize*0.5;
+    const dotHeight = cellSize*0.3;
+    const dotRadius = cellSize*0.15;
     ctx.fillStyle = '#e3e3e3';
     ctx.shadowColor = '#fff';
     ctx.shadowBlur = 6;

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -3,8 +3,8 @@
   --green: #00FF00;
   --green-dark: #00CC00;
   --color-primary: var(--green);
-  --color-bg: #0a0a0a;
-  --color-bg-alt: #1a1a1a;
+  --color-bg: #111215;
+  --color-bg-alt: #181b1e;
   --color-text: #ffffff;
   --font-sans: 'Inter', sans-serif;
   --spacing-sm: 0.5rem;


### PR DESCRIPTION
## Summary
- enlarge logo tube dimensions and deploy Layer III logo sitewide
- fade in login elements for a smoother intro
- align site background with login color palette

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: requires @types/react and @types/node)


------
https://chatgpt.com/codex/tasks/task_e_6896407a61fc832aa155480f1be32ee0