### PR TITLE
Fix BTC hash studio mobile layout and backend loading

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -22,8 +22,8 @@
     .brand .logo{ font-family:'Sixtyfour', sans-serif; font-size: clamp(20px,3vw,30px); letter-spacing:2px; text-shadow:0 1px 6px #000c; }
     .sub{ font-size:12px; opacity:.7; }
     .controls-wrap{ padding: 10px 14px 12px 14px; }
-    .controls{ display:grid; grid-template-columns: repeat(12, minmax(0,1fr)); gap:10px; background:var(--card); border:1px solid var(--border); border-radius:12px; padding:10px; box-shadow:0 2px 20px #0006, 0 0 16px var(--soft) inset; }
-    .ctrl{ grid-column: span 12 / span 12; display:flex; flex-wrap:wrap; align-items:center; gap:8px; background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08); border-radius:10px; padding:8px; }
+    .controls{ width:100%; display:grid; grid-template-columns: repeat(12, minmax(0,1fr)); gap:10px; background:var(--card); border:1px solid var(--border); border-radius:12px; padding:10px; box-shadow:0 2px 20px #0006, 0 0 16px var(--soft) inset; }
+    .ctrl{ grid-column: span 12 / span 12; width:100%; display:flex; flex-wrap:wrap; align-items:center; gap:8px; background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08); border-radius:10px; padding:8px; }
     .ctrl label{ font-size:12px; white-space:nowrap; opacity:.9; }
     .ctrl input[type="text"], .ctrl input[type="number"], .ctrl input[type="range"], .ctrl select{ flex:1 1 auto; min-width:0; background:#000; border:1px solid #333; color:#fff; border-radius:8px; padding:8px 10px; outline:none; }
     .ctrl input[type="range"]{ padding:0; }
@@ -49,11 +49,13 @@
     footer{ flex-shrink:0; border-top:1px solid #1b1d21; background:#0e1114; padding:10px 14px; font-size:12px; color:#aaa; display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:8px; }
     @media (max-width: 1100px){ main{ grid-template-columns: 1fr; grid-template-rows: minmax(60vh,1fr) auto; } #stagePanel{ height:60vh; } }
     @media (max-width: 640px){
+      header{ position:relative; }
+      .controls-wrap{ padding:8px; overflow-x:auto; }
       .controls{ grid-template-columns: 1fr; }
       .ctrl{ grid-column: span 1 / span 1; flex-direction:column; align-items:stretch; }
       .brand{ flex-direction: column; align-items: flex-start; }
-      .controls-wrap{ overflow-x:auto; }
-      main{ gap:8px; padding:8px; }
+      main{ display:flex; flex-direction:column; gap:8px; padding:8px; }
+      #stagePanel{ height:50vh; }
       .overlay{ left:4px; top:4px; right:4px; }
       .chip{ font-size:10px; }
     }
@@ -219,16 +221,17 @@
     // Data fetchers
     async function fetchHistorical(){
       try{
-        const r = await fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1&interval=minute');
-        const j = await r.json();
-        if(j.prices && j.total_volumes) return j;
+        const r = await fetch('/api/btc/historical', { cache: 'no-store' });
+        if(r.ok){
+          const j = await r.json();
+          if(j.prices && j.total_volumes) return j;
+        }
+        throw 0;
       }catch(_){
         try{
-          const r = await fetch('/api/btc/historical', { cache: 'no-store' });
-          if(r.ok){
-            const j = await r.json();
-            if(j.prices && j.total_volumes) return j;
-          }
+          const r = await fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1&interval=minute');
+          const j = await r.json();
+          if(j.prices && j.total_volumes) return j;
         }catch{}
         const now = Date.now();
         const pts = Array.from({length:120},(_,i)=>[now - (120-i)*60_000, 50000 + Math.sin(i/8)*1200 + (Math.random()-.5)*400]);
@@ -237,27 +240,27 @@
     }
     async function fetchHashrate(){
       try{
-        const [hashResp, diffResp] = await Promise.all([
-          fetch('https://api.blockchain.info/q/hashrate?cors=true'),
-          fetch('https://api.blockchain.info/q/getdifficulty?cors=true')
-        ]);
-        if(hashResp.ok && diffResp.ok){
-          const h = parseFloat(await hashResp.text());
-          const d = parseFloat(await diffResp.text());
+        const r = await fetch('/api/btc/stats', { cache: 'no-store' });
+        if(r.ok){
+          const j = await r.json();
           return {
-            hashrate: (h/1e9).toFixed(2) + " EH/s",
-            diff: (d/1e12).toFixed(2) + " T"
+            hashrate: j.hashrate ? j.hashrate.toFixed(2) + " EH/s" : "—",
+            diff: j.diff ? (j.diff/1e12).toFixed(2) + " T" : "—"
           };
         }
         throw 0;
       }catch(_){
         try{
-          const r = await fetch('/api/btc/stats', { cache: 'no-store' });
-          if(r.ok){
-            const j = await r.json();
+          const [hashResp, diffResp] = await Promise.all([
+            fetch('https://api.blockchain.info/q/hashrate?cors=true'),
+            fetch('https://api.blockchain.info/q/getdifficulty?cors=true')
+          ]);
+          if(hashResp.ok && diffResp.ok){
+            const h = parseFloat(await hashResp.text());
+            const d = parseFloat(await diffResp.text());
             return {
-              hashrate: j.hashrate ? j.hashrate.toFixed(2) + " EH/s" : "—",
-              diff: j.diff ? (j.diff/1e12).toFixed(2) + " T" : "—"
+              hashrate: (h/1e9).toFixed(2) + " EH/s",
+              diff: (d/1e12).toFixed(2) + " T"
             };
           }
         }catch{}
@@ -265,30 +268,32 @@
       }
     }
     async function latestBlockHash(){
-      const urls = [
-        'https://blockchain.info/latestblock',
-        'https://blockstream.info/api/blocks/tip/hash'
-      ];
-      for(const url of urls){
-        try{
-          const r = await fetch(url);
-          if(!r.ok) continue;
-          if(url.includes('latestblock')){
-            const j = await r.json();
-            if(j.hash) return j.hash;
-          }else{
-            const t = (await r.text()).trim();
-            if(/^[0-9a-f]{64}$/i.test(t)) return t;
-          }
-        }catch{}
-      }
       try{
         const r = await fetch('/api/btc/latest-hash', { cache: 'no-store' });
         if(r.ok){
           const j = await r.json();
           if(j.hash) return j.hash;
         }
-      }catch{}
+        throw 0;
+      }catch(_){
+        const urls = [
+          'https://blockchain.info/latestblock',
+          'https://blockstream.info/api/blocks/tip/hash'
+        ];
+        for(const url of urls){
+          try{
+            const r = await fetch(url);
+            if(!r.ok) continue;
+            if(url.includes('latestblock')){
+              const j = await r.json();
+              if(j.hash) return j.hash;
+            }else{
+              const t = (await r.text()).trim();
+              if(/^[0-9a-f]{64}$/i.test(t)) return t;
+            }
+          }catch{}
+        }
+      }
       return null;
     }
     function randomHash(){ const hex="0123456789abcdef"; let s=""; for(let i=0;i<64;i++) s+=hex[Math.floor(Math.random()*16)]; return s; }


### PR DESCRIPTION
## Summary
- ensure BTC hash studio pulls data from backend before falling back to public APIs
- refine studio layout so control panel and visualization stack cleanly on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974cdb300c832a865e9b4d5cc16a5f