### PR TITLE
feat: improve mobile btc hash and add whitepaper

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,0 +1,5 @@
+# QUANTUMI Whitepaper (Draft)
+
+This repository documents a private project currently led by a single developer. The forthcoming whitepaper will describe the platform's architecture, data pipeline, and governance plans.
+
+Updates and revisions will be added as development progresses.

--- a/frontend/index-2025.html
+++ b/frontend/index-2025.html
@@ -12,8 +12,8 @@
     *, *::before, *::after { box-sizing: border-box; }
     :root {
       --quantumi-green: #00FF00;
-      --quantumi-black: #010101;
-      --quantumi-white: #F8F8F8;
+      --quantumi-black: #111215;
+      --quantumi-white: #e3e3e3;
       --quantumi-gray: #1A1A1A;
       --quantumi-accent: #FFD966;
       --quantumi-radius: 18px;
@@ -30,6 +30,10 @@
       color: var(--quantumi-white);
       scroll-behavior: smooth;
   }
+  ::selection {
+      background: var(--quantumi-green);
+      color: #000;
+  }
   body {
       overflow-y: auto;
       overflow-x: hidden;
@@ -42,6 +46,17 @@
       display: grid;
       grid-template-rows: auto 1fr auto;
       padding: 1rem;
+    }
+
+    .bg-video {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      z-index: -1;
+      filter: brightness(0.4);
     }
 
     header {
@@ -96,6 +111,9 @@
     }
 
     nav a:hover {
+      color: var(--quantumi-green);
+    }
+    nav a:focus, nav a:active {
       color: var(--quantumi-green);
     }
 
@@ -200,6 +218,9 @@
   </style>
 </head>
 <body>
+  <video id="intro-video" class="bg-video" autoplay muted loop playsinline>
+    <source src="INTRO TRAILER.mp4" type="video/mp4" />
+  </video>
   <div class="container">
     <header>
       <div class="logo">QUANTUMI</div>
@@ -207,14 +228,14 @@
         <a href="https://quantumi.space">Home</a>
         <a href="/investor.html">Investor Hub</a>
         <a href="#">Mint</a>
-        <a href="#">Whitepaper</a>
+        <a href="whitepaper.html">Whitepaper</a>
       </nav>
     </header>
 
   <main class="dashboard">
       <section id="about" class="module-card">
         <h1>Why QUANTUMI?</h1>
-        <p>QUANTUMI fuses on-chain telemetry with user-led research to unlock actionable metrics and foster innovation across the crypto space. Our layered entry system empowers communities to explore data, contribute insights, and shape the next generation of crypto analytics.</p>
+        <p>QUANTUMI fuses on-chain telemetry with user-led research to unlock actionable metrics and foster innovation across the crypto space. This private initiative—currently spearheaded by a single developer—invites explorers to participate as the vision evolves. A comprehensive whitepaper is in preparation to outline the roadmap, protocols, and long-term mission.</p>
       </section>
       <section id="insights" class="module-card">
         <h2>Insights Module Playlist</h2>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1874,18 +1874,52 @@
                                 width: 100vw;
                                 height: 100vh;
                         }
-			.btc-hash-svg {
-				background: #000000;
-				border: 1px solid var(--shadow-color);
-				border-radius: 6px;
-				box-shadow: 0 0 4px var(--shadow-color);
-				position: relative;
-			}
-			#btc-audio-canvas {
-				width: 100%;
-				height: 80px;
-				pointer-events: none;
-			}
+                        .btc-hash-svg {
+                                background: #000000;
+                                border: 1px solid var(--shadow-color);
+                                border-radius: 6px;
+                                box-shadow: 0 0 4px var(--shadow-color);
+                                position: relative;
+                        }
+                        #btc-audio-canvas {
+                                width: 100%;
+                                height: 80px;
+                                pointer-events: none;
+                        }
+                        #btc-mobile-exit {
+                                display: none;
+                        }
+                        @media (max-width: 640px) {
+                                .btc-hash-container.mobile-open {
+                                        position: fixed;
+                                        top: 0;
+                                        left: 0;
+                                        width: 100vw;
+                                        height: 100vh;
+                                        background: #000;
+                                        z-index: 1000;
+                                        padding: 0;
+                                }
+                                .btc-hash-container.mobile-open section {
+                                        height: 100%;
+                                }
+                                .btc-hash-container.mobile-open #btc-hash-canvas {
+                                        height: 100% !important;
+                                        opacity: 1;
+                                }
+                                .btc-hash-container.mobile-open #btc-mobile-exit {
+                                        display: block;
+                                        position: absolute;
+                                        top: 10px;
+                                        right: 10px;
+                                        background: rgba(0, 0, 0, 0.6);
+                                        color: #00FF00;
+                                        border: 1px solid #00FF00;
+                                        border-radius: 6px;
+                                        padding: 6px 10px;
+                                        z-index: 1001;
+                                }
+                        }
 			@keyframes fadeIn {
 				from {
 					opacity: 0;
@@ -3312,8 +3346,9 @@
 				</div>
 			</section>
 		</main>
-		<div class="btc-hash-container w-full max-w-[98vw] mx-auto text-center">
-			<section class="rounded-lg" draggable="true" id="btc-hash-module">
+               <div class="btc-hash-container w-full max-w-[98vw] mx-auto text-center">
+                       <button id="btc-mobile-exit" aria-label="Close BTC view">Exit</button>
+                       <section class="rounded-lg" draggable="true" id="btc-hash-module">
 				<div class="module-header">
 					<h2 class="text-lg md:text-xl sixtyfour-font">
 						&gt; BTC Hash Visualization
@@ -3790,6 +3825,7 @@
                                 exportObjBtn: document.getElementById('export-obj'),
                                 exportFbxBtn: document.getElementById('export-fbx'),
                                 btcFullscreenBtn: document.getElementById('btc-fullscreen-btn'),
+                                btcMobileExit: document.getElementById('btc-mobile-exit'),
                                 zoomInBtn: document.getElementById('btc-zoom-in'),
 				zoomOutBtn: document.getElementById('btc-zoom-out'),
 				zoomZ0Btn: document.getElementById('btc-zoom-z0'),
@@ -6949,6 +6985,7 @@ function setupModuleToggles() {
 
                                if (DOM.btcFullscreenBtn) {
                                        const btcCanvas = document.getElementById('btc-hash-canvas');
+                                       const btcContainer = document.querySelector('.btc-hash-container');
                                        const isFS = () =>
                                                document.fullscreenElement ||
                                                document.webkitFullscreenElement ||
@@ -6968,9 +7005,17 @@ function setupModuleToggles() {
                                                if (ex) ex.call(document);
                                        };
                                        DOM.btcFullscreenBtn.addEventListener('click', () => {
-                                               if (!isFS()) requestFS(btcCanvas);
-                                               else exitFS();
+                                               if (window.innerWidth <= 640) {
+                                                       btcContainer.classList.add('mobile-open');
+                                               } else {
+                                                       if (!isFS()) requestFS(btcCanvas);
+                                                       else exitFS();
+                                               }
                                        });
+                                       if (DOM.btcMobileExit)
+                                               DOM.btcMobileExit.addEventListener('click', () => {
+                                                       btcContainer.classList.remove('mobile-open');
+                                               });
                                        document.addEventListener('fullscreenchange', () => {
                                                btcCanvas.classList.toggle('fs-active', !!isFS());
                                        });

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -115,6 +115,11 @@
       /* Fullscreen */
       .fs-target:fullscreen, .fs-target:-webkit-full-screen{ background:#000; width:100%; height:100%; }
       .fs-btn-on{ display:none; } .fs-active .fs-btn-on{ display:inline-flex; } .fs-active .fs-btn-off{ display:none; }
+
+      @media (max-width:640px){
+        body.mobile-open #stagePanel{ position:fixed; inset:0; width:100vw; height:100vh; z-index:1000; }
+        body.mobile-open .mobile-fs-btn{ position:fixed; right:12px; top:12px; z-index:1001; }
+      }
     
     </style>
 
@@ -781,8 +786,28 @@
       function exitFS(){ const ex= document.exitFullscreen || document.webkitExitFullscreen || document.msExitFullscreen; if(ex) ex.call(document); document.body.classList.remove('fs-active'); setTimeout(resize, 100); }
       btnFS.addEventListener('click', ()=> requestFS(stagePanel));
       btnExit.addEventListener('click', exitFS);
-      if(mobileFSBtn){ mobileFSBtn.addEventListener('click', ()=>{ if(!isFullscreen()) requestFS(stagePanel); else exitFS(); }); }
-      document.addEventListener('fullscreenchange', ()=>{ const active=!!isFullscreen(); document.body.classList.toggle('fs-active', active); if(mobileFSBtn){ mobileFSBtn.textContent = active ? '✕' : '⤢'; mobileFSBtn.setAttribute('aria-label', active ? 'Exit fullscreen' : 'Enter fullscreen'); } setTimeout(resize, 80); });
+      if(mobileFSBtn){
+        mobileFSBtn.addEventListener('click', ()=>{
+          if(window.innerWidth <= 640){
+            const open=document.body.classList.toggle('mobile-open');
+            mobileFSBtn.textContent = open ? '✕' : '⤢';
+            mobileFSBtn.setAttribute('aria-label', open ? 'Exit view' : 'Enter view');
+            if(open) resize();
+          } else {
+            if(!isFullscreen()) requestFS(stagePanel); else exitFS();
+          }
+        });
+      }
+      document.addEventListener('fullscreenchange', ()=>{
+        const active=!!isFullscreen();
+        document.body.classList.toggle('fs-active', active);
+        if(mobileFSBtn && window.innerWidth > 640){
+          mobileFSBtn.textContent = active ? '✕' : '⤢';
+          mobileFSBtn.setAttribute('aria-label', active ? 'Exit fullscreen' : 'Enter fullscreen');
+        }
+        if(!active) document.body.classList.remove('mobile-open');
+        setTimeout(resize, 80);
+      });
 
       // Export
       $('export-png').addEventListener('click', ()=>{

--- a/frontend/whitepaper.html
+++ b/frontend/whitepaper.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>QUANTUMI Whitepaper (Draft)</title>
+  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,700&display=swap" rel="stylesheet">
+  <style>
+    :root{ --bg:#111215; --fg:#e3e3e3; --green:#00FF00; }
+    body{ margin:0; padding:2rem; font-family:'Satoshi',sans-serif; background:var(--bg); color:var(--fg); }
+    h1{ color:var(--green); }
+    a{ color:var(--green); }
+  </style>
+</head>
+<body>
+  <h1>QUANTUMI Whitepaper</h1>
+  <p>This document is a living draft for a private project currently led by a single developer. The full whitepaper will expand on the platform's architecture, data methodologies, and community governance.</p>
+  <p>Updates will be published here as development progresses.</p>
+  <p><a href="index-2025.html">Return to site</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mobile overlay and exit control for BTC hash on landing and studio pages
- refresh 2025 index with cinematic video, login-matched colors, and whitepaper link
- draft initial whitepaper documentation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897debe0a74832aaa648a6525331af4