### PR TITLE
Improve mobile BTC hash view and login responsiveness

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1919,6 +1919,10 @@
                                         padding: 6px 10px;
                                         z-index: 1001;
                                 }
+                                .btc-hash-container.mobile-open .module-header,
+                                .btc-hash-container.mobile-open .module-content > *:not(.btc-hash-svg) {
+                                        display: none;
+                                }
                         }
 			@keyframes fadeIn {
 				from {

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -17,7 +17,8 @@
       font-family: 'Sora', sans-serif;
       background: #111215;
       color: #e3e3e3cc;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
       scroll-behavior: smooth;
     }
     #access-overlay {
@@ -35,7 +36,8 @@
       padding: clamp(0.5em, 2vh, 1.5em) 1em;
       padding-bottom: calc(env(safe-area-inset-bottom) + 3rem);
       box-sizing: border-box;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     #overlay-content {
       display: flex;


### PR DESCRIPTION
## Summary
- Hide BTC hash module headers and controls when opened on mobile for a clean fullscreen visualization
- Allow scrolling on login overlay and body to match index page responsiveness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e51db7a0832ab0ff626c79a7256f