### PR TITLE
Restyle studio controls and move below viewer

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -36,31 +36,30 @@
       .right{ margin-left:auto; display:flex; align-items:center; gap:.6rem; flex-wrap:wrap; }
 
       /* --- CONTROLS ----------------------------------------------------------- */
-      .controls-rail{ padding:10px 14px 12px; }
-      .controls{ width:100%; display:grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap:10px; background:var(--card); border:1px solid var(--border); border-radius:12px; padding:10px; box-shadow:0 2px 20px #0006, 0 0 16px var(--soft) inset; }
+      #controls-toggle{ display:inline-flex; margin:0 14px 12px; }
+      .controls-rail{ padding:10px 14px 12px; flex-shrink:0; }
+      .controls{ width:100%; display:grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap:10px; background:rgba(12,12,12,0.94); border:1px solid #444; border-radius:12px; padding:14px; box-shadow:0 2px 20px #000a; }
       .btn-row{ display:flex; flex-wrap:wrap; gap:8px; }
       .nowrap{ white-space:nowrap; }
       .ellipsis{ overflow:hidden; text-overflow:ellipsis; }
-      .btn-row{ display:flex; flex-wrap:wrap; gap:8px; }
-      .nowrap{ white-space:nowrap; }
-      .ellipsis{ overflow:hidden; text-overflow:ellipsis; }
-      .ctrl{ width:100%; display:flex; flex-wrap:wrap; align-items:center; gap:8px; background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08); border-radius:10px; padding:10px; min-height:52px; }
+      .ctrl{ width:100%; display:flex; flex-wrap:wrap; align-items:center; gap:8px; background:#0c0f12; border:1px solid rgba(255,255,255,.08); border-radius:10px; padding:10px; min-height:52px; }
       .ctrl label{ font-size:12px; white-space:nowrap; opacity:.9; }
-      .ctrl input[type="text"], .ctrl input[type="number"], .ctrl input[type="range"], .ctrl select, .ctrl input[type="email"], .ctrl input[type="file"]{ flex:1 1 auto; min-width:0; background:#000; border:1px solid #333; color:#fff; border-radius:8px; padding:10px; outline:none; }
+      .ctrl input[type="text"], .ctrl input[type="number"], .ctrl input[type="range"], .ctrl select, .ctrl input[type="email"], .ctrl input[type="file"]{ flex:1 1 auto; min-width:0; background:#000; border:1.5px solid #444; color:#fff; border-radius:6px; padding:10px; outline:none; }
       .ctrl input[type="range"]{ padding:0; -webkit-appearance:none; appearance:none; background:transparent; }
       .ctrl input[type="range"]::-webkit-slider-runnable-track{ height:4px; background:rgba(0,255,0,.3); border-radius:2px; }
       .ctrl input[type="range"]::-webkit-slider-thumb{ -webkit-appearance:none; width:14px; height:14px; border-radius:50%; background:#00ff00; cursor:pointer; margin-top:-5px; }
       .ctrl input[type="range"]::-moz-range-track{ height:4px; background:rgba(0,255,0,.3); border-radius:2px; }
       .ctrl input[type="range"]::-moz-range-thumb{ width:14px; height:14px; border-radius:50%; background:#00ff00; cursor:pointer; }
-      .btn{ background:rgba(0,255,0,.15); border:1px solid rgba(0,255,0,.3); color:#e7e7e7; border-radius:10px; padding:10px 12px; cursor:pointer; transition:background .18s, transform .06s; min-width:44px; min-height:44px; }
-      .btn:hover{ background:rgba(0,255,0,.3); color:#001; border-color:var(--border); }
+      .btn{ background:#fff; border:none; color:#000; border-radius:6px; padding:10px 12px; cursor:pointer; transition:background .18s, color .18s, transform .06s; min-width:44px; min-height:44px; }
+      .btn:hover{ background:#35e1ad; color:#111; }
       .btn:active{ transform: translateY(1px); }
 
-      /* Mobile controls drawer */
-      #controls-toggle{ display:none; }
+      .controls-rail[aria-hidden="true"]{ max-height:0; overflow:hidden; padding:0 14px; }
+      .controls-rail[aria-hidden="false"]{ max-height:1200px; transition:max-height .25s ease; }
+
       @media (max-width: 640px){
         .controls-rail{ padding:0 8px 8px; }
-        #controls-toggle{ display:inline-flex; margin:0 8px 8px; }
+        #controls-toggle{ margin:0 8px 8px; }
         .controls{ grid-template-columns:1fr; }
         .ctrl{ flex-direction:column; align-items:stretch; gap:6px; }
         .ctrl > *{ width:100%; min-width:0; }
@@ -68,22 +67,6 @@
         .btn.block{ width:100%; }
         .brand{ flex-direction:column; align-items:flex-start; }
         .btn-row{ display:grid; grid-template-columns: 1fr 1fr; gap:8px; }
-        .controls-rail[aria-hidden="true"]{ max-height:0; overflow:hidden; border:0; padding:0 8px; }
-        .controls-rail[aria-hidden="false"]{ max-height:1400px; transition:max-height .25s ease; }
-        input[type="file"]{ width:100%; }
-        input[type="text"], input[type="email"], select{ width:100%; }
-      }
-        #controls-toggle{ display:inline-flex; margin:0 8px 8px; }
-        .controls{ grid-template-columns:1fr; }
-        .ctrl{ flex-directio
-        #controls-toggle{ display:inline-flex; margin:0 8px 8px; }
-        .controls{ grid-template-columns:1fr; }
-        .ctrl{ flex-direction:column; align-items:stretch; }
-        .btn.block{ width:100%; }
-        .brand{ flex-direction:column; align-items:flex-start; }
-        /* Drawer behaviour */
-        .controls-rail[aria-hidden="true"]{ max-height:0; overflow:hidden; border:0; padding:0 8px; }
-        .controls-rail[aria-hidden="false"]{ max-height:1200px; transition:max-height .25s ease; }
       }
 
       /* --- LAYOUT ------------------------------------------------------------- */
@@ -141,57 +124,6 @@
         </div>
       </div>
       <button id="controls-toggle" class="btn" type="button" aria-expanded="false" aria-controls="controls-rail">Controls</button>
-      <div id="controls-rail" class="controls-rail" aria-hidden="false">
-        <div class="controls">
-        <div class="controls">
-          <div class="ctrl" title="Upload a compact FBX (5–10MB).">
-            <label>Upload FBX</label>
-            <input type="file" id="fbx-file" accept=".fbx" />
-            <div class="btn-row"><button class="btn" id="btn-load-fbx" title="Pick an FBX file">Load FBX</button><button class="btn" id="clear-fbx">Clear</button><button class="btn fs-btn-off" id="btn-fullscreen" title="Enter fullscreen">Fullscreen</button><button class="btn fs-btn-on" id="btn-exitfs" title="Exit fullscreen">Exit FS</button></div>
-            <button class="btn right fs-btn-off" id="btn-fullscreen" title="Enter fullscreen">Fullscreen</button>
-            <button class="btn right fs-btn-on" id="btn-exitfs" title="Exit fullscreen">Exit FS</button>
-          </div>
-          <div class="ctrl" title="Mapping from data to space. ‘Original’ uses time→Z, price→X, volume→Y.">
-            <label>Mapping</label>
-            <select id="mapping">
-              <option value="original" selected>Original (Time/Price/Volume)</option>
-              <option value="spiral">Spiral (time-curve)</option>
-              <option value="sphere">Sphere (volatility radius)</option>
-              <option value="helix">Helix (momentum tilt)</option>
-            </select>
-          </div>
-          <div class="ctrl" title="Instances per data point.">
-            <label>Density</label>
-            <input type="range" id="density" min="1" max="200" value="60" />
-          </div>
-          <div class="ctrl" title="Point size for dot clouds.">
-            <label>Point Size</label>
-            <input type="range" id="pointSize" min="0.02" max="0.6" step="0.02" value="0.12" />
-          </div>
-          <div class="ctrl" title="Color mode for clouds/instances.">
-            <label>Theme</label>
-            <select id="theme">
-              <option value="original" selected>Original</option>
-              <option value="heatmap">Heatmap (volatility)</option>
-              <option value="lifecycle">Lifecycle (volume)</option>
-            </select>
-          </div>
-          <div class="ctrl" title="Paste a hash, or use the latest block. Used when Mapping ≠ Original.">
-            <label>Hash</label>
-            <input id="hashInput" type="text" placeholder="Paste a block/tx hash…" inputmode="latin" autocomplete="off" />
-            <button class="btn" id="btnLatest">Latest</button>
-            <button class="btn" id="btnRandom">Random</button>
-            <button class="btn" id="btnGenerate">Generate</button>
-          </div>
-          <div class="ctrl" title="Export the current scene and data.">
-            <label>Export</label>
-            <button class="btn" id="export-fbx">FBX</button>
-            <button class="btn" id="export-png">PNG</button>
-            <button class="btn" id="export-csv">CSV</button>
-            <button class="btn right" id="reset-view" title="Reset camera">Reset</button>
-          </div>
-        </div>
-      </div><!-- /#controls-rail -->
     </header>
 
     <main id="main">
@@ -239,6 +171,55 @@
       </aside>
     </main>
 
+    <div id="controls-rail" class="controls-rail" aria-hidden="false">
+      <div class="controls">
+        <div class="ctrl" title="Upload a compact FBX (5–10MB).">
+          <label>Upload FBX</label>
+          <input type="file" id="fbx-file" accept=".fbx" />
+          <div class="btn-row"><button class="btn" id="btn-load-fbx" title="Pick an FBX file">Load FBX</button><button class="btn" id="clear-fbx">Clear</button><button class="btn fs-btn-off" id="btn-fullscreen" title="Enter fullscreen">Fullscreen</button><button class="btn fs-btn-on" id="btn-exitfs" title="Exit fullscreen">Exit FS</button></div>
+        </div>
+        <div class="ctrl" title="Mapping from data to space. ‘Original’ uses time→Z, price→X, volume→Y.">
+          <label>Mapping</label>
+          <select id="mapping">
+            <option value="original" selected>Original (Time/Price/Volume)</option>
+            <option value="spiral">Spiral (time-curve)</option>
+            <option value="sphere">Sphere (volatility radius)</option>
+            <option value="helix">Helix (momentum tilt)</option>
+          </select>
+        </div>
+        <div class="ctrl" title="Instances per data point.">
+          <label>Density</label>
+          <input type="range" id="density" min="1" max="200" value="60" />
+        </div>
+        <div class="ctrl" title="Point size for dot clouds.">
+          <label>Point Size</label>
+          <input type="range" id="pointSize" min="0.02" max="0.6" step="0.02" value="0.12" />
+        </div>
+        <div class="ctrl" title="Color mode for clouds/instances.">
+          <label>Theme</label>
+          <select id="theme">
+            <option value="original" selected>Original</option>
+            <option value="heatmap">Heatmap (volatility)</option>
+            <option value="lifecycle">Lifecycle (volume)</option>
+          </select>
+        </div>
+        <div class="ctrl" title="Paste a hash, or use the latest block. Used when Mapping ≠ Original.">
+          <label>Hash</label>
+          <input id="hashInput" type="text" placeholder="Paste a block/tx hash…" inputmode="latin" autocomplete="off" />
+          <button class="btn" id="btnLatest">Latest</button>
+          <button class="btn" id="btnRandom">Random</button>
+          <button class="btn" id="btnGenerate">Generate</button>
+        </div>
+        <div class="ctrl" title="Export the current scene and data.">
+          <label>Export</label>
+          <button class="btn" id="export-fbx">FBX</button>
+          <button class="btn" id="export-png">PNG</button>
+          <button class="btn" id="export-csv">CSV</button>
+          <button class="btn right" id="reset-view" title="Reset camera">Reset</button>
+        </div>
+      </div>
+    </div><!-- /#controls-rail -->
+
     <footer>
       <span>© 2025 <span style="font-family:'Sixtyfour',sans-serif">QUANTUMI</span> — All Rights Reserved.</span>
       <a href="https://www.instagram.com/quantumi.space/" target="_blank" rel="noopener" class="text-green-400 underline">Instagram</a>
@@ -251,7 +232,7 @@
       const nfPct = new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 2 });
       const canvas = $('btc-hash-canvas'); const stagePanel = $('stagePanel');
 
-      // Mobile controls drawer toggle (match reference layout)
+      // Controls drawer toggle
       const drawerBtn = $('controls-toggle');
       const rail = $('controls-rail');
       if (drawerBtn && rail) {


### PR DESCRIPTION
## Summary
- Rework studio control panel layout so viewer is on top and controls sit beneath
- Restyle controls and buttons with login page aesthetic and add toggleable drawer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a8b6f3cc832aab8437e5ec05111c