### PR TITLE
feat: enhance studio FBX upload and add theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,6 +95,15 @@
                                 flex-direction: column;
                                 line-height: 1.6;
                         }
+                        body.light {
+                                filter: invert(1) hue-rotate(180deg);
+                        }
+                        body.light img,
+                        body.light video,
+                        body.light canvas,
+                        body.light iframe {
+                                filter: invert(1) hue-rotate(180deg);
+                        }
                         body.locked > :not(#access-overlay) {
                                 display: none !important;
                         }
@@ -2420,6 +2429,7 @@
         <body
                 class="text-white min-h-screen flex flex-col overflow-x-hidden overflow-y-auto scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-[\#00FF00]"
         >
+               <button id="theme-toggle" class="fixed top-2 right-2 z-50 bg-green-500 text-black px-2 py-1 rounded">Light</button>
                <div id="access-overlay">
                        <div id="overlay-content">
                                <canvas id="qCanvas" class="q-hero-canvas fade-in" width="600" height="600" style="animation-delay:0s"></canvas>
@@ -7754,6 +7764,23 @@ function setupModuleToggles() {
                                 }
                         });
                         updateModeLabel();
+                </script>
+                <script>
+                        (function(){
+                                const toggle=document.getElementById('theme-toggle');
+                                if(!toggle) return;
+                                const setTheme=(mode)=>{
+                                        document.body.classList.toggle('light', mode==='light');
+                                        toggle.textContent = mode==='light' ? 'Dark' : 'Light';
+                                };
+                                const saved=localStorage.getItem('site-theme')||'dark';
+                                setTheme(saved);
+                                toggle.addEventListener('click',()=>{
+                                        const next=document.body.classList.contains('light')?'dark':'light';
+                                        setTheme(next);
+                                        localStorage.setItem('site-theme',next);
+                                });
+                        })();
                 </script>
         </body>
 </html>

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -157,7 +157,7 @@
           <ul class="list-disc ml-5 space-y-1">
             <li>‘Original’ mapping is live market-derived (time/price/volume).</li>
             <li>Switch to Spiral/Sphere/Helix to use a BTC hash (Latest/Manual/Random).</li>
-            <li>Large FBX files (100MB+) are supported, though performance may vary.</li>
+            <li>Large FBX files (up to 500MB) are supported, though performance may vary.</li>
             <li>Use <b>Fullscreen</b> for presentations; works on mobile too.</li>
           </ul>
         </div>
@@ -174,7 +174,7 @@
 
     <div id="controls-rail" class="controls-rail" aria-hidden="false">
       <div class="controls">
-        <div class="ctrl" title="Upload FBX models (supports files over 100MB).">
+        <div class="ctrl" title="Upload FBX models (supports files up to 500MB).">
           <label>Upload FBX</label>
           <input type="file" id="fbx-file" accept=".fbx" />
           <div class="btn-row"><button class="btn" id="btn-load-fbx" title="Pick an FBX file">Load FBX</button><button class="btn" id="clear-fbx">Clear</button><button class="btn fs-btn-off" id="btn-fullscreen" title="Enter fullscreen">Fullscreen</button><button class="btn fs-btn-on" id="btn-exitfs" title="Exit fullscreen">Exit FS</button></div>
@@ -232,6 +232,7 @@
       const nfUSD = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
       const nfPct = new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 2 });
       const canvas = $('btc-hash-canvas'); const stagePanel = $('stagePanel');
+      const MAX_FBX_SIZE = 500 * 1024 * 1024; // 500MB limit
 
       // Controls drawer toggle
       const drawerBtn = $('controls-toggle');
@@ -756,6 +757,12 @@
       $('fbx-file').addEventListener('change', async (e)=>{
         const file=e.target.files && e.target.files[0];
         if(!file){ userFBX=null; return; }
+        if(file.size > MAX_FBX_SIZE){
+          alert('FBX file exceeds 500MB limit.');
+          e.target.value='';
+          userFBX=null;
+          return;
+        }
         try{
           const buffer=await file.arrayBuffer();
           userFBX=loader.parse(buffer, '');


### PR DESCRIPTION
## Summary
- allow FBX uploads up to 500MB in BTC Hash Studio with explicit file size guard
- introduce simple light/dark theme toggle for dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c6e343aa8832abc2b1c62a225fe40