### PR TITLE
chore: remove instagram links and emoji-based menu icons

### DIFF
--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -13,7 +13,7 @@ const ThemeToggle = () => {
       onClick={() => setTheme(current === 'dark' ? 'light' : 'dark')}
       className="fixed top-4 right-4 z-50 p-2 rounded-md bg-carbon/60 backdrop-blur-md text-accent"
     >
-      {current === 'dark' ? '🌙' : '☀️'}
+      {current === 'dark' ? '◐' : '◑'}
     </button>
   );
 };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2462,9 +2462,6 @@
                                                <input id="mailing-email" type="email" placeholder="Email for updates" class="rounded px-3 py-2 text-black w-full" required />
                                                <button type="submit" class="login-btn">Join Mailing List</button>
                                        </form>
-                                       <div class="mt-2 text-center">
-                                               <a href="https://www.instagram.com/quantumi.space/" target="_blank" class="text-xs text-green-400 underline">Instagram</a>
-                                       </div>
                                    </div>
                                  </div>
                                  <div class="buttons fade-in" style="animation-delay:1s">
@@ -2682,7 +2679,7 @@
 				</p>
 				<nav>
                                         <a class="nav-link" href="#world-module">QuantumI Insights</a>
-                                        <a class="nav-link" href="#tokens-module">Tokens ✨</a>
+                                        <a class="nav-link" href="#tokens-module">Tokens</a>
                                         <a class="nav-link" href="#gas-module">Gas &amp; Fees</a>
                                        <a class="nav-link" href="#balances-module">Finance Tweets</a>
                                        <a class="nav-link" href="#wallet-module">Wallet</a>
@@ -2718,7 +2715,7 @@
 						<span id="loading-time"></span>
 						<span id="loading-date"></span>
 					</div>
-					<button id="mute-btn" aria-label="Toggle mute">🔇</button>
+                                        <button id="mute-btn" aria-label="Toggle mute">M</button>
 				</div>
 				<div class="title-box">
                                         <h1 class="text-2xl md:text-3xl main-title">QUANTUMI</h1>
@@ -3301,7 +3298,7 @@
 								id="chart-export-btn"
 								onclick="exportChart()"
 							>
-								📤 Export
+                                                               Export
 							</button>
 						</div>
 					</div>
@@ -3317,19 +3314,19 @@
                                 id="wallet-module"
 			>
 				<div class="module-header flex justify-between items-center">
-                                        <h2 class="text-lg md:text-xl text-white">🔐 Wallet & Tokens</h2>
+                                        <h2 class="text-lg md:text-xl text-white">Wallet & Tokens</h2>
 					<div class="flex gap-2">
 						<button
 							class="text-white py-1 px-4 rounded text-sm"
 							id="connectWallet"
 						>
-							🔌 Connect Wallet
+                                                       Connect Wallet
 						</button>
 						<button
 							class="text-white py-1 px-4 rounded text-sm"
 							id="refreshWalletData"
 						>
-							🔄 Refresh Wallet
+                                                       Refresh Wallet
 						</button>
 						<button
 							class="text-white py-1 px-2 rounded text-xs"
@@ -6240,7 +6237,7 @@ function setupModuleToggles() {
 					DOM.muteBtn.addEventListener('click', () => {
 						if (!DOM.introVideo) return;
 						DOM.introVideo.muted = !DOM.introVideo.muted;
-						DOM.muteBtn.textContent = DOM.introVideo.muted ? '🔇' : '🔊';
+                                           DOM.muteBtn.textContent = DOM.introVideo.muted ? 'M' : 'S';
 					});
 				}
                                 if (DOM.playIntroBtn) {
@@ -6257,11 +6254,11 @@ function setupModuleToggles() {
 						if (!bgMusicPlayer) return;
 						if (bgMusicPlayer.isMuted()) {
 							bgMusicPlayer.unMute();
-							DOM.musicMuteBtn.textContent = '🔊';
+                                                  DOM.musicMuteBtn.textContent = 'S';
 							DOM.musicMuteBtn.classList.add('active');
 						} else {
 							bgMusicPlayer.mute();
-							DOM.musicMuteBtn.textContent = '🔇';
+                                                  DOM.musicMuteBtn.textContent = 'M';
 							DOM.musicMuteBtn.classList.remove('active');
 						}
 					});

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -249,9 +249,6 @@
               <input id="mailing-email" type="email" placeholder="Email for updates" class="rounded px-3 py-2 text-black w-full" required />
               <button type="submit" class="login-btn">Join Mailing List</button>
             </form>
-            <div class="mt-2 text-center">
-              <a href="https://www.instagram.com/quantumi.space/" target="_blank" class="text-xs text-green-400 underline">Instagram</a>
-            </div>
           </div>
         </div>
         <div class="buttons fade-in" style="animation-delay:1s">

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -123,12 +123,12 @@
         <div class="logo">QUANTUMI</div>
         <div class="sub">BTC Hash Studio — Pro</div>
         <div class="right">
-          <a class="btn" id="home-btn" href="index.html" title="Home">🏠</a>
-          <button class="btn" id="toggle-log" title="Show/Hide log">📜</button>
-          <button class="btn" id="toggle-metrics" title="Show/Hide metrics">📊</button>
+          <a class="btn" id="home-btn" href="index.html" title="Home">⌂</a>
+          <button class="btn" id="toggle-log" title="Show/Hide log">≡</button>
+          <button class="btn" id="toggle-metrics" title="Show/Hide metrics">Σ</button>
           <div class="seg" role="group" aria-label="Theme">
-            <button class="btn" id="theme-dark" aria-pressed="true" title="Dark">🌙</button>
-            <button class="btn" id="theme-light" aria-pressed="false" title="Light">☀️</button>
+            <button class="btn" id="theme-dark" aria-pressed="true" title="Dark">◐</button>
+            <button class="btn" id="theme-light" aria-pressed="false" title="Light">◑</button>
           </div>
           <div class="sub">v3.4</div>
         </div>
@@ -244,7 +244,6 @@
 
     <footer>
       <span>© 2025 <span style="font-family:'Sixtyfour',sans-serif">QUANTUMI</span> — All Rights Reserved.</span>
-      <a href="https://www.instagram.com/quantumi.space/" target="_blank" rel="noopener" class="text-green-400 underline">Instagram</a>
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- drop Instagram references from login, index and studio pages
- replace emoji icons in menus with plain symbols and text
- swap theme toggle emojis for neutral glyphs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce7c680dc832ab89e782cb2c7415e