### PR TITLE
fix: improve mobile fullscreen height

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -117,7 +117,7 @@
       /* Fullscreen */
       .fs-target:fullscreen, .fs-target:-webkit-full-screen{ background:#000; width:100%; height:100%; }
       .fs-btn-on{ display:none; } .fs-active .fs-btn-on{ display:inline-flex; } .fs-active .fs-btn-off{ display:none; }
-      .fs-fallback{ position:fixed; inset:0; width:100vw; height:100vh; z-index:9999; background:#000; }
+      .fs-fallback{ position:fixed; inset:0; width:100vw; height:100vh; height:100dvh; z-index:9999; background:#000; }
       body.fs-noscroll{ overflow:hidden; }
 
       /* Reduced motion */


### PR DESCRIPTION
## Summary
- adjust studio fullscreen fallback height using dynamic viewport units for better mobile support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1780fb78832a80735ca4e59c88ea