### PR TITLE
feat: add logo to BTC overlay

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -159,6 +159,7 @@
         <div class="stage">
           <button id="mobile-fs-toggle" class="mobile-fs-btn" aria-label="Toggle fullscreen">⤢</button>
           <div class="overlay" id="metrics">
+            <canvas class="quantumi-logo w-12 h-12" aria-label="Quantumi logo"></canvas>
             <div class="chip" id="m-price">Price —</div>
             <div class="chip" id="m-volume">Volume —</div>
             <div class="chip" id="m-change">24h —</div>
@@ -260,6 +261,7 @@
       <span>© 2025 <span style="font-family:'Sixtyfour',sans-serif">QUANTUMI</span> — All Rights Reserved.</span>
     </footer>
 
+    <script src="quantumi-logo.js"></script>
     <script>
       // --- Theme toggle (Light / Dark). Remembers choice. iOS-ready light.
       (function initTheme(){


### PR DESCRIPTION
## Summary
- add Quantumi logo to BTC metrics overlay in studio view
- load logo script to render the overlay icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2672431c832a9f503a02416d33b3