### PR TITLE
Improve light and dark mode styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,28 +90,28 @@
                                 --focus: var(--primary-color);
                                 --ring: rgba(0,255,0,.35);
                         }
-                        body {
-                                font-family: 'Inter', 'Segoe UI', sans-serif;
-                                background: var(--bg-color);
-                                color: var(--text-color);
-                                margin: 0;
-                                min-height: 100vh;
-                                display: flex;
-                                flex-direction: column;
-                                line-height: 1.6;
+                       body {
+                               font-family: 'Inter', 'Segoe UI', sans-serif;
+                               background: var(--bg-color);
+                               color: var(--text-color);
+                               margin: 0;
+                               min-height: 100vh;
+                               display: flex;
+                               flex-direction: column;
+                               line-height: 1.6;
+                               transition: background-color .3s,color .3s;
                         }
-                        body.light {
-                                filter: invert(1) hue-rotate(180deg);
-                        }
-                        body.light img,
-                        body.light video,
-                        body.light canvas,
-                        body.light iframe {
-                                filter: invert(1) hue-rotate(180deg);
-                        }
-                        body.locked > :not(#access-overlay) {
-                                display: none !important;
-                        }
+                       body.light {
+                               --bg-color: var(--quantumi-white);
+                               --text-color: var(--quantumi-black);
+                               --panel-bg: rgba(255,255,255,.7);
+                               --panel-brd: rgba(0,0,0,.1);
+                               --card: rgba(255,255,255,.7);
+                               --shadow-color: rgba(0,255,0,.2);
+                       }
+                       body.locked > :not(#access-overlay) {
+                               display: none !important;
+                       }
                        .btn{ background:var(--card); border:1px solid var(--focus); color:var(--text-color); border-radius:12px; padding:10px 14px; cursor:pointer; transition:background .18s,color .18s,transform .06s,border-color .18s; min-width:44px; min-height:44px; }
                        .btn:hover,.btn:focus{ background:var(--focus); color:#0b0d0f; outline:none; box-shadow:0 0 0 4px var(--ring); }
                        .btn:active{ transform:translateY(1px); }


### PR DESCRIPTION
## Summary
- refine light and dark theme handling using CSS variables
- add smooth transitions for theme switch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9cb64c70832a8351bcb30ff1a293