### PR TITLE
feat: add photography gallery and social template tools

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7665,13 +7665,13 @@ function setupModuleToggles() {
 						}
 					}
 				});
-				window.inverseChart = inverseChart;
-			}
+                                window.inverseChart = inverseChart;
+                        }
 
-			// Add event listeners to toggle buttons for responsiveness
-			document.getElementById('topCount').addEventListener('change', (e) => {
-				loadInverseChart(parseInt(e.target.value));
-			});
+                        // Add event listeners to toggle buttons for responsiveness
+                        document.getElementById('topCount').addEventListener('change', (e) => {
+                                loadInverseChart(parseInt(e.target.value));
+                        });
 
                         window.addEventListener('load', () => {
                                 const unlocked = localStorage.getItem('quanti-email');
@@ -7684,6 +7684,170 @@ function setupModuleToggles() {
                                 }
                         });
                 </script>
+               <!-- AGLM Photography Section -->
+               <section id="aglm-photography" class="p-4">
+                       <h2 class="text-2xl mb-2">Photography</h2>
+                       <div id="aglm-do-gallery" class="aglm-gallery mb-4"></div>
+                       <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=4ARHEk46o" loading="lazy" style="width:100%;border:none;" title="AGLM Pinterest"></iframe>
+                       <div class="mt-4">
+                               <label for="aglm-dont-upload" class="block mb-2">Don't Uploads</label>
+                               <input id="aglm-dont-upload" type="file" accept="image/png,image/jpeg,image/webp,video/mp4" multiple class="mb-2" />
+                               <div id="aglm-dont-gallery" class="aglm-gallery"></div>
+                       </div>
+               </section>
+
+               <!-- AGLM Social Template Section -->
+               <section id="aglm-social-template" class="p-4">
+                       <h2 class="text-2xl mb-2">Social Template</h2>
+                       <div id="aglm-template-controls" class="mb-4">
+                               <select id="aglm-template-type" class="border p-1 mr-2">
+                                       <option value="event">Event Announcement</option>
+                                       <option value="save">Save the Date</option>
+                               </select>
+                               <select id="aglm-aspect-ratio" class="border p-1 mr-2">
+                                       <option value="1:1">1080x1080</option>
+                                       <option value="4:5">1080x1350</option>
+                               </select>
+                               <input id="aglm-headline" type="text" placeholder="Headline" class="border p-1 mr-2" />
+                               <textarea id="aglm-details" placeholder="Details" class="border p-1 mr-2"></textarea>
+                               <input id="aglm-bg-url" type="text" placeholder="Background Image URL (optional)" class="border p-1 mr-2" />
+                               <button id="aglm-generate" class="btn mr-2">Generate</button>
+                               <button id="aglm-download" class="btn mr-2">Download PNG</button>
+                               <button id="aglm-print" class="btn">Print/Save PDF</button>
+                       </div>
+                       <canvas id="aglm-instagram-canvas" width="1080" height="1080"></canvas>
+               </section>
+
+               <style>
+               #aglm-photography h2,
+               #aglm-social-template h2{font-family:'Modak',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;}
+               .aglm-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:10px;}
+               .aglm-gallery img,.aglm-gallery video{width:100%;border-radius:8px;}
+               #aglm-template-controls{display:flex;flex-wrap:wrap;gap:0.5rem;}
+               #aglm-template-controls > *{flex:1 1 200px;}
+               #aglm-instagram-canvas{max-width:100%;border:1px solid #ccc;}
+               </style>
+               <script>
+               (function(){
+                       const THIRTY_DAYS = 30*24*60*60*1000;
+                       function populateDoGallery(){
+                               const section=document.getElementById('aglm-photography');
+                               const doGallery=document.getElementById('aglm-do-gallery');
+                               if(!section||!doGallery) return;
+                               const media=section.querySelectorAll('img,video');
+                               media.forEach(el=>{
+                                       if(el.closest('#aglm-do-gallery,#aglm-dont-gallery')) return;
+                                       const src=el.getAttribute('src')||'';
+                                       if(/\.(png|jpe?g|webp|mp4)(\?|$)/i.test(src)){
+                                               doGallery.appendChild(el.cloneNode(true));
+                                       }
+                               });
+                       }
+
+                       function loadDontGallery(){
+                               const gallery=document.getElementById('aglm-dont-gallery');
+                               if(!gallery) return;
+                               const stored=JSON.parse(localStorage.getItem('aglm-dont-items')||'[]');
+                               const now=Date.now();
+                               const fresh=stored.filter(item=>now-item.timestamp<THIRTY_DAYS);
+                               if(fresh.length!==stored.length){localStorage.setItem('aglm-dont-items',JSON.stringify(fresh));}
+                               fresh.forEach(item=>{
+                                       const el=item.type.startsWith('video')?document.createElement('video'):document.createElement('img');
+                                       if(item.type.startsWith('video')) el.controls=true;
+                                       el.src=item.data;
+                                       gallery.appendChild(el);
+                               });
+                       }
+
+                       function handleDontUpload(files){
+                               const gallery=document.getElementById('aglm-dont-gallery');
+                               const stored=JSON.parse(localStorage.getItem('aglm-dont-items')||'[]');
+                               Array.from(files).forEach(file=>{
+                                       const reader=new FileReader();
+                                       reader.onload=e=>{
+                                               const data=e.target.result;
+                                               const item={data,type:file.type,timestamp:Date.now()};
+                                               stored.push(item);
+                                               const el=file.type.startsWith('video')?document.createElement('video'):document.createElement('img');
+                                               if(file.type.startsWith('video')) el.controls=true;
+                                               el.src=data;
+                                               gallery.appendChild(el);
+                                               localStorage.setItem('aglm-dont-items',JSON.stringify(stored));
+                                       };
+                                       reader.readAsDataURL(file);
+                               });
+                       }
+
+                       function initDontUpload(){
+                               const input=document.getElementById('aglm-dont-upload');
+                               if(!input) return;
+                               input.addEventListener('change',e=>handleDontUpload(e.target.files));
+                       }
+
+                       function setCanvasSize(canvas,ratio){
+                               canvas.width=1080;
+                               canvas.height=ratio==='4:5'?1350:1080;
+                       }
+
+                       function wrapText(ctx,text,x,y,maxWidth,lineHeight){
+                               const words=text.split(' ');
+                               let line='';
+                               for(let n=0;n<words.length;n++){const testLine=line+words[n]+' ';const metrics=ctx.measureText(testLine);if(metrics.width>maxWidth&&n>0){ctx.fillText(line,x,y);line=words[n]+' ';y+=lineHeight;}else{line=testLine;}}ctx.fillText(line,x,y);
+                       }
+
+                       function generateTemplate(){
+                               const type=document.getElementById('aglm-template-type').value;
+                               const ratio=document.getElementById('aglm-aspect-ratio').value;
+                               const headline=document.getElementById('aglm-headline').value;
+                               const details=document.getElementById('aglm-details').value;
+                               const bgUrl=document.getElementById('aglm-bg-url').value.trim();
+                               const canvas=document.getElementById('aglm-instagram-canvas');
+                               const ctx=canvas.getContext('2d');
+                               setCanvasSize(canvas,ratio);
+                               const draw=()=>{
+                                       ctx.fillStyle='#0C3C57';
+                                       ctx.fillRect(0,0,canvas.width,canvas.height);
+                                       if(bgUrl){const img=new Image();img.crossOrigin='anonymous';img.onload=()=>{const scale=Math.max(canvas.width/img.width,canvas.height/img.height);const w=img.width*scale;const h=img.height*scale;const x=(canvas.width-w)/2;const y=(canvas.height-h)/2;ctx.drawImage(img,x,y,w,h);overlay();};img.onerror=overlay;img.src=bgUrl;}else{overlay();}
+                               };
+                               const overlay=()=>{
+                                       ctx.fillStyle='#D7A86E';
+                                       ctx.textAlign='center';
+                                       ctx.font='80px Modak,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
+                                       ctx.fillText(headline,canvas.width/2,canvas.height*0.3);
+                                       ctx.font='40px Modak,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
+                                       wrapText(ctx,details,canvas.width/2,canvas.height*0.45,canvas.width*0.8,50);
+                                       ctx.font='32px Modak,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
+                                       ctx.fillText('AGLM',canvas.width/2,canvas.height-40);
+                               };
+                               draw();
+                       }
+
+                       function downloadPNG(){
+                               const canvas=document.getElementById('aglm-instagram-canvas');
+                               const link=document.createElement('a');
+                               link.download='aglm-instagram.png';
+                               link.href=canvas.toDataURL('image/png');
+                               link.click();
+                       }
+
+                       function printPDF(){
+                               const canvas=document.getElementById('aglm-instagram-canvas');
+                               const data=canvas.toDataURL('image/png');
+                               const win=window.open('');
+                               win.document.write('<img src="'+data+'" style="width:100%">');
+                               win.document.close();win.focus();win.print();
+                       }
+
+                       document.addEventListener('DOMContentLoaded',()=>{
+                               populateDoGallery();
+                               loadDontGallery();
+                               initDontUpload();
+                               document.getElementById('aglm-generate').addEventListener('click',generateTemplate);
+                               document.getElementById('aglm-download').addEventListener('click',downloadPNG);
+                               document.getElementById('aglm-print').addEventListener('click',printPDF);
+                       });
+               })();
+               </script>
                 <footer style="text-align:center;padding:0.5rem 0;font-size:0.8rem;color:var(--quantumi-gray);">
                         © <span class="sixtyfour-font">QUANTUMI</span> 2025. All Rights Reserved.
                 </footer>


### PR DESCRIPTION
## Summary
- add Photography section with automatic Do gallery, Pinterest embed, and persistent Don't gallery
- add Instagram social template generator with canvas controls and export options
- include styles and scripts for offline operation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e05e89cec832ab0f2962af2a378b1