### PR TITLE
fix: ensure BTC hash chart remains interactive

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -86,7 +86,7 @@
       #controls-toggle{ display:inline-flex; margin:0 14px 12px; }
       #controls-rail{ grid-area:controls; }
       .controls-rail{ padding:10px 14px 12px; flex-shrink:0; transition:max-height .25s ease; overflow:hidden; position:sticky; top:0; z-index:40; }
-      .controls-rail[aria-hidden="true"]{ max-height:0; padding:0 14px; }
+      .controls-rail[aria-hidden="true"]{ max-height:0; padding:0 14px; pointer-events:none; }
       .controls-rail[aria-hidden="false"]{ max-height:80vh; overflow-y:auto; padding:10px 14px 12px; }
       @media (max-width:640px){
         .controls-rail{


### PR DESCRIPTION
## Summary
- prevent hidden controls rail from capturing pointer events that block the BTC hash visualization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f86c00f68832aa4cf20eaed93e955