### PR TITLE
feat: add external fallback for BTC metrics

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -340,14 +340,36 @@
         try {
           return await fetchWithRetry('/api/btc/historical');
         } catch {
-          return null;
+          try {
+            return await fetchWithRetry('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1');
+          } catch {
+            const now = Date.now();
+            const prices=[], vols=[];
+            let p=60000, v=4_500_000;
+            for(let i=23;i>=0;i--){
+              const t=now - i*3600*1000;
+              prices.push([t,p]);
+              vols.push([t,v]);
+              p+=(Math.random()-.5)*1000;
+              v+=(Math.random()-.5)*100000;
+            }
+            return { prices, total_volumes: vols };
+          }
         }
       }
       async function fetchBTCStats(){
         try {
           return await fetchWithRetry('/api/btc/stats');
         } catch {
-          return { hashrate: 0, diff: 0 };
+          try {
+            const [hashrateText, diffText] = await Promise.all([
+              fetchTextWithRetry('https://api.blockchain.info/q/hashrate?cors=true'),
+              fetchTextWithRetry('https://api.blockchain.info/q/getdifficulty?cors=true')
+            ]);
+            return { hashrate: parseFloat(hashrateText)/1e9, diff: parseFloat(diffText) };
+          } catch {
+            return { hashrate: 0, diff: 0 };
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- fall back to CoinGecko/Blockchain.info when `/api/btc/*` endpoints fail
- generate sample price and volume data if external APIs unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f94610b0c832a85ab5ba40661b53b