### PR TITLE
fix: add backend fallback for btc price

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -299,6 +299,22 @@ app.get('/api/live-logs', async (req, res) => {
 });
 
 // BTC metrics endpoints used by the studio front-end
+app.get('/api/btc/price', async (_req, res) => {
+  try {
+    const { data } = await axios.get('https://api.coingecko.com/api/v3/coins/bitcoin', {
+      timeout: 10000,
+    });
+    res.json({
+      price: data.market_data.current_price.usd,
+      volume: data.market_data.total_volume.usd,
+      change: data.market_data.price_change_percentage_24h,
+    });
+  } catch (err) {
+    console.error('Error fetching BTC price:', err.message);
+    res.json({ price: 60000, volume: 4_500_000, change: 0 });
+  }
+});
+
 app.get('/api/btc/historical', async (_req, res) => {
   try {
     const url = 'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart';

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -326,14 +326,18 @@
       }
       async function fetchBTCPrice(){
         try {
-          const d = await fetchWithRetry('https://api.coingecko.com/api/v3/coins/bitcoin');
-          return {
-            price: d.market_data.current_price.usd,
-            volume: d.market_data.total_volume.usd,
-            change: d.market_data.price_change_percentage_24h
-          };
+          return await fetchWithRetry('/api/btc/price');
         } catch {
-          return { price:60000, volume:4_500_000, change:0 };
+          try {
+            const d = await fetchWithRetry('https://api.coingecko.com/api/v3/coins/bitcoin');
+            return {
+              price: d.market_data.current_price.usd,
+              volume: d.market_data.total_volume.usd,
+              change: d.market_data.price_change_percentage_24h
+            };
+          } catch {
+            return { price:60000, volume:4_500_000, change:0 };
+          }
         }
       }
       async function fetchBTCHistorical(){


### PR DESCRIPTION
## Summary
- add server-side fallback when fetching BTC price
- keep displaying metrics even when external API fails
- expose `/api/btc/price` endpoint providing BTC price, volume, and change with default fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9c469dd8832a90b10cb16f4de194