### PR TITLE
Add BTC hash visualizer studio

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,86 @@
+import { createPointCloud, updatePointSize, updateDensity, applyGenerativeMapping } from './pointcloud.js';
+import { setupFirstPersonControls, enablePlayHUD, disablePlayHUD, resetCamera } from './controls.js';
+import { parseBTCPointData } from './btcDataWorker.js';
+import { toggleFullscreen } from './fullscreen.js';
+
+const canvas = document.getElementById('webgl');
+const statusText = document.getElementById('statusText');
+const fpsEl = document.getElementById('fps');
+
+let renderer, scene, camera, pointCloud;
+let tickRAF;
+
+init();
+
+async function init() {
+  renderer = new THREE.WebGLRenderer({ canvas, antialias: false, powerPreference: 'high-performance' });
+  renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+  resize();
+  addEventListener('resize', resize, { passive: true });
+
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x05070a);
+  scene.fog = new THREE.FogExp2(0x04060a, 0.0012);
+
+  camera = new THREE.PerspectiveCamera(70, canvas.clientWidth / canvas.clientHeight, 0.1, 2000);
+  camera.position.set(0, 3, 8);
+
+  const hemi = new THREE.HemisphereLight(0x7db0ff, 0x08121a, 0.8);
+  scene.add(hemi);
+
+  statusText.textContent = 'Loading Bitcoin point data…';
+  const btcData = await parseBTCPointData(); // { positions: Float32Array, seeds: Uint32Array }
+
+  pointCloud = createPointCloud(btcData, { scene });
+
+  const ctrl = setupFirstPersonControls({ camera, canvas, scene, collider: pointCloud.collider });
+
+  document.getElementById('applyPrompt').onclick = () => {
+    const prompt = document.getElementById('prompt').value.trim();
+    applyGenerativeMapping(pointCloud, prompt);
+  };
+  document.getElementById('size').oninput = (e) => updatePointSize(pointCloud, parseFloat(e.target.value));
+  document.getElementById('density').oninput = (e) => updateDensity(pointCloud, parseFloat(e.target.value));
+  document.getElementById('resetCam').onclick = () => resetCamera(camera);
+  document.getElementById('playBtn').onclick = async () => {
+    await toggleFullscreen(canvas);
+    ctrl.lock();
+  };
+
+  ctrl.onLock = () => { enablePlayHUD(); };
+  ctrl.onUnlock = () => { disablePlayHUD(); };
+
+  statusText.textContent = 'Ready.';
+  requestIdleCallback?.(() => renderer.compile(scene, camera));
+
+  let last = performance.now();
+  const stats = { frames: 0, lastFPS: performance.now() };
+
+  const target = 58;
+  tickRAF = () => {
+    const now = performance.now();
+    const dt = Math.min((now - last) / 1000, 0.05);
+    last = now;
+
+    stats.frames++;
+    if (now - stats.lastFPS > 1000) {
+      const fps = Math.round((stats.frames * 1000) / (now - stats.lastFPS));
+      fpsEl.textContent = `${fps} fps`;
+      stats.frames = 0; stats.lastFPS = now;
+
+      if (fps < target - 8) updateDensity(pointCloud, Math.max(0.2, pointCloud.userDensity * 0.9));
+      else if (fps > target + 8) updateDensity(pointCloud, Math.min(1.0, pointCloud.userDensity * 1.05));
+    }
+
+    ctrl.update(dt);
+    renderer.render(scene, camera);
+    requestAnimationFrame(tickRAF);
+  };
+  requestAnimationFrame(tickRAF);
+}
+
+function resize() {
+  const w = canvas.clientWidth, h = canvas.clientHeight;
+  renderer?.setSize(w, h, false);
+  if (camera) { camera.aspect = w / h; camera.updateProjectionMatrix(); }
+}

--- a/btcDataWorker.js
+++ b/btcDataWorker.js
@@ -1,0 +1,25 @@
+// Swap this with your real BTC point cloud source. Keep the return shape.
+
+export async function parseBTCPointData() {
+  // Expected return shape: { positions: Float32Array[n*3], seeds: Uint32Array[n] }
+  // For now, generate a deterministic mock cloud (stable seed) so the app runs.
+  const n = 150_000;
+  const positions = new Float32Array(n * 3);
+  const seeds = new Uint32Array(n);
+
+  let s = 0xdeadbeef;
+  const rand = () => (s = (s ^ (s << 13)) >>> 0, s = (s ^ (s >>> 17)) >>> 0, s = (s ^ (s << 5)) >>> 0, s / 0xffffffff);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / n * Math.PI * 32.0;
+    const r = 40 + 30 * rand();
+    const x = Math.cos(t) * r + (rand() - 0.5) * 6;
+    const z = Math.sin(t) * r + (rand() - 0.5) * 6;
+    const y = (rand() - 0.5) * 8 + Math.sin(i*0.001) * 1.2;
+    positions[i*3+0] = x;
+    positions[i*3+1] = y;
+    positions[i*3+2] = z;
+    seeds[i] = (rand() * 0xffffffff) >>> 0;
+  }
+  return { positions, seeds };
+}

--- a/controls.js
+++ b/controls.js
@@ -1,0 +1,78 @@
+// First-person controls with walk/run/jump bounded by the point cloud AABB
+
+export function setupFirstPersonControls({ camera, canvas, scene, collider }) {
+  const controls = new THREE.PointerLockControls(camera, canvas);
+  scene.add(controls.getObject());
+
+  const velocity = new THREE.Vector3();
+  const direction = new THREE.Vector3();
+  const params = {
+    moveForward: false, moveBackward: false, moveLeft: false, moveRight: false,
+    run: false, onGround: false, gravity: 28, speed: 9, runMul: 1.8, jumpVel: 10
+  };
+
+  const onKeyDown = (e) => {
+    switch(e.code) {
+      case 'ArrowUp': case 'KeyW': params.moveForward = true; break;
+      case 'ArrowLeft': case 'KeyA': params.moveLeft = true; break;
+      case 'ArrowDown': case 'KeyS': params.moveBackward = true; break;
+      case 'ArrowRight': case 'KeyD': params.moveRight = true; break;
+      case 'ShiftLeft': case 'ShiftRight': params.run = true; break;
+      case 'Space': if (params.onGround) { velocity.y += params.jumpVel; params.onGround = false; } break;
+    }
+  };
+  const onKeyUp = (e) => {
+    switch(e.code) {
+      case 'ArrowUp': case 'KeyW': params.moveForward = false; break;
+      case 'ArrowLeft': case 'KeyA': params.moveLeft = false; break;
+      case 'ArrowDown': case 'KeyS': params.moveBackward = false; break;
+      case 'ArrowRight': case 'KeyD': params.moveRight = false; break;
+      case 'ShiftLeft': case 'ShiftRight': params.run = false; break;
+    }
+  };
+
+  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener('keyup', onKeyUp);
+
+  controls.update = (dt) => {
+    if (!controls.isLocked) return;
+
+    velocity.x -= velocity.x * 8.0 * dt;
+    velocity.z -= velocity.z * 8.0 * dt;
+    velocity.y -= 28 * dt;
+
+    direction.set(
+      (params.moveRight?1:0) - (params.moveLeft?1:0),
+      0,
+      (params.moveBackward?1:0) - (params.moveForward?1:0)
+    ).normalize();
+
+    const speed = 9 * (params.run ? 1.8 : 1.0);
+    if (direction.lengthSq() > 0) {
+      const front = new THREE.Vector3();
+      controls.getDirection(front);
+      front.y = 0; front.normalize();
+      const right = new THREE.Vector3().crossVectors(front, new THREE.Vector3(0,1,0)).negate();
+      velocity.addScaledVector(front, -direction.z * speed * dt * 60);
+      velocity.addScaledVector(right,  direction.x * speed * dt * 60);
+    }
+
+    controls.getObject().position.addScaledVector(velocity, dt);
+
+    const pos = controls.getObject().position;
+    const floorY = collider.min.y + 1.6;
+    if (pos.y <= floorY) { velocity.y = 0; pos.y = floorY; params.onGround = true; } else { params.onGround = false; }
+
+    pos.x = Math.max(collider.min.x - 2, Math.min(collider.max.x + 2, pos.x));
+    pos.z = Math.max(collider.min.z - 2, Math.min(collider.max.z + 2, pos.z));
+  };
+
+  controls.onLock = () => {};
+  controls.onUnlock = () => {};
+
+  return controls;
+}
+
+export function enablePlayHUD() { document.getElementById('hud').classList.remove('hidden'); }
+export function disablePlayHUD() { document.getElementById('hud').classList.add('hidden'); }
+export function resetCamera(camera) { camera.position.set(0, 3, 8); camera.rotation.set(0, 0, 0); }

--- a/fullscreen.js
+++ b/fullscreen.js
@@ -1,0 +1,7 @@
+export async function toggleFullscreen(element) {
+  if (!document.fullscreenElement) {
+    await element.requestFullscreen?.();
+  } else {
+    await document.exitFullscreen?.();
+  }
+}

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -1,0 +1,160 @@
+// GPU-instanced sprites + shader morphing seeded by BTC hash data
+
+export function createPointCloud(btcData, { scene }) {
+  const count = btcData.positions.length / 3;
+
+  const geometry = new THREE.InstancedBufferGeometry();
+  const base = new THREE.PlaneGeometry(1, 1).toNonIndexed();
+  geometry.index = base.index;
+  geometry.attributes.position = base.attributes.position;
+  geometry.attributes.uv = base.attributes.uv;
+
+  geometry.instanceCount = count;
+  geometry.setAttribute('iOffset', new THREE.InstancedBufferAttribute(btcData.positions, 3));
+  const sizes = new Float32Array(count); sizes.fill(1.0);
+  geometry.setAttribute('iSize', new THREE.InstancedBufferAttribute(sizes, 1));
+  geometry.setAttribute('iSeed', new THREE.InstancedBufferAttribute(new Float32Array(btcData.seeds), 1));
+
+  const material = new THREE.RawShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    uniforms: {
+      uTime: { value: 0 },
+      uSize: { value: 1.2 },
+      uDensity: { value: 1.0 },
+      uColorA: { value: new THREE.Color(0x67ffb7) },
+      uColorB: { value: new THREE.Color(0x3ea1ff) },
+      uTheme: { value: 0 },
+      uPromptHash: { value: new THREE.Vector4(0,0,0,0) },
+      uSpriteSoft: { value: 0.7 },
+      projectionMatrix: { value: null }, viewMatrix: { value: null }, modelMatrix: { value: null }
+    },
+    vertexShader: `
+      precision highp float;
+      uniform mat4 projectionMatrix, viewMatrix, modelMatrix;
+      uniform float uTime, uSize, uDensity;
+      uniform int uTheme;
+      uniform vec4 uPromptHash;
+      attribute vec3 position;
+      attribute vec2 uv;
+      attribute vec3 iOffset;
+      attribute float iSize;
+      attribute float iSeed;
+
+      float hash11(float p) {
+        p = fract(p * 0.1031);
+        p *= p + 33.33;
+        p *= p + p;
+        return fract(p);
+      }
+      vec3 hash31(float p) {
+        return vec3(hash11(p), hash11(p+17.1), hash11(p+31.7));
+      }
+      float noise3(vec3 x){
+        vec3 i = floor(x), f = fract(x);
+        f = f*f*(3.0-2.0*f);
+        float n = dot(i, vec3(1.0, 57.0, 113.0));
+        float res = mix(
+          mix(mix(hash11(n+0.0), hash11(n+1.0), f.x),
+              mix(hash11(n+57.0), hash11(n+58.0), f.x), f.y),
+          mix(mix(hash11(n+113.0), hash11(n+114.0), f.x),
+              mix(hash11(n+170.0), hash11(n+171.0), f.x), f.y), f.z);
+        return res;
+      }
+
+      vec3 themeDisplace(int theme, vec3 p, float seed) {
+        float t = uTime * 0.3 + seed*3.1;
+        if (theme == 1) { float h = noise3(p*0.035 + t*0.2); return vec3(0.0, h*0.6, 0.0); }
+        if (theme == 2) { float h = noise3(p*0.07) * 2.0 - 0.6; return vec3(0.0, h, 0.0); }
+        if (theme == 3) { vec3 g = floor((p + uPromptHash.xyz*20.0) / 4.0) * 4.0;
+                          float h = noise3(g*0.12 + seed) * 8.0; return vec3(0.0, h, 0.0); }
+        if (theme == 4) { float w = sin(p.x*0.08 + t)*0.5 + cos(p.z*0.08 - t*1.2)*0.5; return vec3(0.0, w*0.7, 0.0); }
+        if (theme == 5) { float h = max(0.0, noise3(p*0.05 + t*0.4) - 0.5) * 1.4; return vec3(0.0, h, 0.0); }
+        if (theme == 6) { vec3 dir = normalize(uPromptHash.xyz*2.0 - 1.0 + 1e-5);
+                          float m = noise3(p*0.06 + uPromptHash.xyz*2.0 + t*0.3) * 1.2; return dir * m; }
+        return vec3(0.0);
+      }
+
+      void main() {
+        if (fract(iSeed*0.618) > uDensity) { gl_Position = vec4(2.0,2.0,2.0,1.0); return; }
+        vec3 world = iOffset + themeDisplace(uTheme, iOffset, iSeed);
+        vec3 right = vec3(viewMatrix[0][0], viewMatrix[1][0], viewMatrix[2][0]);
+        vec3 up    = vec3(viewMatrix[0][1], viewMatrix[1][1], viewMatrix[2][1]);
+        float size = iSize * uSize;
+        vec3 pos = world + (right * (position.x * size)) + (up * (position.y * size));
+        gl_Position = projectionMatrix * viewMatrix * modelMatrix * vec4(pos, 1.0);
+      }
+    `,
+    fragmentShader: `
+      precision highp float;
+      uniform vec3 uColorA, uColorB;
+      uniform int uTheme;
+      uniform float uSpriteSoft;
+      void main() {
+        vec2 p = (gl_PointCoord - 0.5) * 2.0;
+        float r = length(p);
+        float alpha = smoothstep(0.9, uSpriteSoft, 1.0 - r);
+        vec3 color = mix(uColorA, uColorB, r);
+        if (uTheme == 1) color = mix(vec3(0.42,0.86,0.47), vec3(0.2,0.6,0.3), r);
+        if (uTheme == 2) color = mix(vec3(0.55,0.55,0.58), vec3(0.33,0.33,0.36), r);
+        if (uTheme == 3) color = mix(vec3(0.65,0.80,1.0), vec3(0.15,0.35,0.6), r);
+        if (uTheme == 4) color = mix(vec3(0.2,0.6,0.9), vec3(0.03,0.15,0.35), r);
+        if (uTheme == 5) color = mix(vec3(0.98,0.42,0.67), vec3(0.98,0.89,0.35), r*r);
+        gl_FragColor = vec4(color, alpha);
+        if (gl_FragColor.a < 0.02) discard;
+      }
+    `,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.frustumCulled = false;
+  scene.add(mesh);
+
+  const collider = new THREE.Box3().setFromBufferAttribute(new THREE.BufferAttribute(btcData.positions, 3)).expandByScalar(10);
+
+  (function animateTime(){
+    material.uniforms.uTime.value = performance.now() / 1000;
+    requestAnimationFrame(animateTime);
+  })();
+
+  return { mesh, material, geometry, collider, userDensity: 1.0 };
+}
+
+export function updatePointSize(pc, size) {
+  pc.material.uniforms.uSize.value = size;
+}
+export function updateDensity(pc, density) {
+  pc.userDensity = density;
+  pc.material.uniforms.uDensity.value = density;
+}
+export function applyGenerativeMapping(pc, prompt) {
+  const theme = inferTheme(prompt);
+  pc.material.uniforms.uTheme.value = theme.code;
+  pc.material.uniforms.uColorA.value.set(theme.colorA);
+  pc.material.uniforms.uColorB.value.set(theme.colorB);
+  pc.material.uniforms.uPromptHash.value.set(...hashPrompt4(prompt));
+}
+
+function inferTheme(prompt='') {
+  const p = prompt.toLowerCase();
+  const t = (code, colorA, colorB)=>({ code, colorA, colorB });
+  if (/(grass|meadow|field|forest|green)/.test(p)) return t(1,0x6bdc7a,0x1e6a37);
+  if (/(rock|stone|canyon|mountain)/.test(p))     return t(2,0x8d8d93,0x333338);
+  if (/(city|neon|cyber|building|tower)/.test(p)) return t(3,0xa6c8ff,0x1b3f66);
+  if (/(water|ocean|sea|lake|wave)/.test(p))      return t(4,0x56a7e6,0x0a2749);
+  if (/(flower|bloom|garden)/.test(p))            return t(5,0xfb6aa9,0xf6e85a);
+  if (!p) return t(0,0x67ffb7,0x3ea1ff);
+  return t(6,0xd2b2ff,0x7be3ff);
+}
+
+function hashPrompt4(str) {
+  let h1 = 1779033703, h2 = 3144134277, h3 = 1013904242, h4 = 2773480762;
+  for (let i=0;i<str.length;i++) {
+    const k = str.charCodeAt(i);
+    h1 = (h2 ^ Math.imul(h1 ^ k, 597399067)) >>> 0;
+    h2 = (h3 ^ Math.imul(h2 ^ k, 2869860233)) >>> 0;
+    h3 = (h4 ^ Math.imul(h3 ^ k, 951274213)) >>> 0;
+    h4 = (h1 ^ Math.imul(h4 ^ k, 2716044179)) >>> 0;
+  }
+  return [h1/2**32, h2/2**32, h3/2**32, h4/2**32];
+}

--- a/studio.html
+++ b/studio.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>BTC Hash Visualizer — Studio</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">BTC Visual Studio</div>
+    <div class="controls">
+      <input id="prompt" class="prompt" placeholder="Type a style… e.g. 'lush grass', 'rocky canyon', 'neon city'">
+      <button id="applyPrompt">Apply</button>
+      <label class="slider">
+        Point Size
+        <input id="size" type="range" min="0.25" max="4" step="0.05" value="1.2">
+      </label>
+      <label class="slider">
+        Density
+        <input id="density" type="range" min="0.1" max="1" step="0.05" value="1">
+      </label>
+      <button id="playBtn" class="primary">Play (Fullscreen)</button>
+      <button id="resetCam">Reset Camera</button>
+    </div>
+  </header>
+
+  <main id="app">
+    <canvas id="webgl"></canvas>
+    <div id="hud" class="hud hidden">
+      <div class="crosshair"></div>
+      <div class="hint">WASD to move • Space to jump • Shift to run • Esc to exit</div>
+      <div id="fps" class="fps">— fps</div>
+    </div>
+  </main>
+
+  <footer class="status">
+    <span id="statusText">Loading…</span>
+  </footer>
+
+  <!-- Vendor: Three.js + helpers -->
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.1/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.1/examples/js/controls/PointerLockControls.js"></script>
+
+  <!-- App -->
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,44 @@
+:root {
+  --bg: #0b0f14; --fg: #dbe2ec; --muted: #8ca0b3; --accent: #6ee7ff; --primary: #5ee38a;
+}
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; background: var(--bg); color: var(--fg); }
+.topbar {
+  position: fixed; top: 0; left: 0; right: 0; height: 56px;
+  display: flex; align-items: center; justify-content: space-between;
+  background: rgba(12,16,22,0.75); backdrop-filter: blur(8px);
+  padding: 0 12px; z-index: 10; border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.brand { font-weight: 700; letter-spacing: 0.4px; }
+.controls { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.prompt {
+  width: min(40vw, 480px);
+  background: #0d141c; color: var(--fg); border: 1px solid #1c2733; border-radius: 8px;
+  padding: 10px 12px; outline: none;
+}
+button {
+  background: #192330; border: 1px solid #263446; color: var(--fg);
+  padding: 9px 12px; border-radius: 8px; cursor: pointer;
+}
+button.primary { background: #15301f; border-color: #164226; color: var(--primary); }
+button:active { transform: translateY(1px); }
+.slider { color: var(--muted); font-size: 13px; display: flex; align-items: center; gap: 6px; }
+.slider input { accent-color: var(--accent); }
+#webgl { width: 100%; height: 100%; display: block; }
+.hud { position: fixed; inset: 0; pointer-events: none; display: grid; place-items: center; }
+.hud.hidden { display: none; }
+.crosshair { width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.8); border-radius: 50%; }
+.hint {
+  position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+  color: var(--muted); font-size: 12px; background: rgba(0,0,0,0.35); padding: 6px 10px; border-radius: 6px;
+}
+.fps { position: fixed; top: 64px; right: 10px; font-size: 12px; color: var(--muted); }
+.status {
+  position: fixed; bottom: 0; left: 0; right: 0; height: 28px; display: flex; align-items: center;
+  padding: 0 10px; color: var(--muted); background: linear-gradient(180deg, transparent, rgba(0,0,0,0.5));
+  pointer-events: none; user-select: none;
+}
+@media (max-width: 800px) {
+  .controls { gap: 8px; }
+  .prompt { width: min(60vw, 360px); }
+}


### PR DESCRIPTION
## Summary
- Add studio page with UI controls and HUD
- Render GPU-instanced point cloud with thematic shader mapping
- Introduce first-person controls, fullscreen toggle, and mock BTC data source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689faa3cf170832a88c0b73f3460fc32