### PR TITLE
feat: add first-person exploration HUD

### DIFF
--- a/enhance.js
+++ b/enhance.js
@@ -1,0 +1,238 @@
+// QUANTUMI add-on: first-person Explore mode + generative style recoloring (non-destructive)
+// Works with three r128. Depends on window.QUANTUMI (exposed by the patch) and PointerLockControls.
+
+(function(){
+  const wait = (cond, t=50) => new Promise(res=>{
+    const tick=()=>cond()?res():setTimeout(tick,t);
+    tick();
+  });
+
+  document.addEventListener('DOMContentLoaded', async ()=>{
+    await wait(()=>window.QUANTUMI && window.THREE);
+
+    const Q = window.QUANTUMI;
+    const THREE_ = window.THREE;
+    const stage = document.getElementById('stagePanel');
+    const hud = document.getElementById('fp-hud');
+    const playBtn = ensurePlayButton();
+    const styleCtrl = ensureStyleControls();
+
+    // ---------- Explore (First-person) ----------
+    const controlsFP = new THREE_.PointerLockControls(Q.camera, Q.renderer.domElement);
+    Q.scene.add(controlsFP.getObject());
+
+    // movement state
+    const v = new THREE_.Vector3();
+    const dir = new THREE_.Vector3();
+    const up = new THREE_.Vector3(0,1,0);
+    const keys = { f:false,b:false,l:false,r:false,run:false,ground:false };
+    const SPEED=9, RUN=1.8, GRAV=28, JUMP=10, HEIGHT=1.6;
+    let bounds = computeBounds();
+    let active = false;
+
+    // update bounds whenever a new cloud is added (we can hook into your frame loop cheaply)
+    let frameCount = 0;
+    document.addEventListener('quantumi:frame', ()=>{
+      if (!active && ++frameCount % 180 === 0) { bounds = computeBounds(); } // ~3s at 60fps
+      if (!active) return;
+
+      // Integrate simple kinematics each frame
+      const dt = 1/60; // your renderer is already driving the frame rate; we use small fixed step
+      v.x -= v.x * 8 * dt;
+      v.z -= v.z * 8 * dt;
+      v.y -= GRAV * dt;
+
+      dir.set((keys.r?1:0)-(keys.l?1:0), 0, (keys.b?1:0)-(keys.f?1:0)).normalize();
+      if (dir.lengthSq() > 0) {
+        const forward = new THREE_.Vector3();
+        controlsFP.getDirection(forward);
+        forward.y = 0; forward.normalize();
+        const right = new THREE_.Vector3().crossVectors(forward, up).negate();
+        const mul = SPEED * (keys.run?RUN:1);
+        v.addScaledVector(forward, -dir.z * mul * dt * 60);
+        v.addScaledVector(right,   dir.x * mul * dt * 60);
+      }
+
+      const obj = controlsFP.getObject();
+      obj.position.addScaledVector(v, dt);
+
+      // clamp to current point-cloud bounds
+      const floorY = bounds.min.y + HEIGHT;
+      if (obj.position.y <= floorY){ v.y = 0; obj.position.y = floorY; keys.ground = true; } else { keys.ground = false; }
+
+      obj.position.x = Math.max(bounds.min.x-2, Math.min(bounds.max.x+2, obj.position.x));
+      obj.position.z = Math.max(bounds.min.z-2, Math.min(bounds.max.z+2, obj.position.z));
+    });
+
+    function computeBounds(){
+      // Try newest cloud first
+      const clouds = Q.dotClouds || [];
+      const latest = clouds[clouds.length-1];
+      const box = new THREE_.Box3();
+      if (latest && latest.geometry) {
+        latest.geometry.computeBoundingBox?.();
+        if (latest.geometry.boundingBox) return latest.geometry.boundingBox.clone().expandByScalar(2);
+      }
+      // Fallback reasonable stage
+      return new THREE_.Box3(new THREE_.Vector3(-12,-2,-12), new THREE_.Vector3(12,6,12));
+    }
+
+    // key handlers only while pointer-locked
+    function onKeyDown(e){
+      switch(e.code){
+        case 'KeyW': case 'ArrowUp': keys.f = true; break;
+        case 'KeyS': case 'ArrowDown': keys.b = true; break;
+        case 'KeyA': case 'ArrowLeft': keys.l = true; break;
+        case 'KeyD': case 'ArrowRight': keys.r = true; break;
+        case 'ShiftLeft': case 'ShiftRight': keys.run = true; break;
+        case 'Space': if (keys.ground) { v.y += JUMP; keys.ground = false; } break;
+      }
+    }
+    function onKeyUp(e){
+      switch(e.code){
+        case 'KeyW': case 'ArrowUp': keys.f = false; break;
+        case 'KeyS': case 'ArrowDown': keys.b = false; break;
+        case 'KeyA': case 'ArrowLeft': keys.l = false; break;
+        case 'KeyD': case 'ArrowRight': keys.r = false; break;
+        case 'ShiftLeft': case 'ShiftRight': keys.run = false; break;
+      }
+    }
+
+    function enterFP(){
+      // disable Orbit while exploring
+      Q.controls.enabled = false;
+      controlsFP.lock();
+    }
+    function exitFP(){
+      controlsFP.unlock();
+    }
+
+    controlsFP.addEventListener('lock', ()=>{
+      active = true;
+      bounds = computeBounds();
+      hud?.classList.add('on');
+      // place camera on floor if outside
+      const y = bounds.min.y + HEIGHT;
+      if (Q.camera.position.y < y) Q.camera.position.y = y;
+      document.addEventListener('keydown', onKeyDown);
+      document.addEventListener('keyup', onKeyUp);
+    });
+    controlsFP.addEventListener('unlock', ()=>{
+      active = false;
+      hud?.classList.remove('on');
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+      Q.controls.enabled = true;
+    });
+
+    playBtn?.addEventListener('click', enterFP);
+    document.getElementById('mobile-fs-toggle')?.addEventListener('click', ()=>{ /* mobile FS already handled by page */ });
+
+    // ---------- Generative Style Mapping (prompt → live recolor) ----------
+    styleCtrl?.apply.addEventListener('click', ()=>{
+      const prompt = (styleCtrl.input.value || '').trim();
+      if (!prompt) return;
+      recolorAllClouds(prompt);
+    });
+
+    function recolorAllClouds(prompt){
+      const cfg = inferStyle(prompt);
+      const rng = mulberry32(hash32(prompt));
+      for (const cloud of (Q.dotClouds||[])){
+        if (!cloud || !cloud.isPoints || !cloud.geometry) continue;
+        const g = cloud.geometry;
+        const pos = g.getAttribute('position');
+        let col = g.getAttribute('color');
+        if (!col || col.count !== pos.count){
+          col = new THREE_.BufferAttribute(new Float32Array(pos.count*3), 3);
+          g.setAttribute('color', col);
+        }
+        for (let i=0;i<pos.count;i++){
+          const y = pos.getY(i);
+          const t = cfg.mode==='noise'
+            ? (rng() * 0.4 + 0.6*Math.max(0,Math.min(1,(y - cfg.yMin)/(cfg.yMax-cfg.yMin+1e-6))))
+            : Math.max(0,Math.min(1,(y - cfg.yMin)/(cfg.yMax-cfg.yMin+1e-6)));
+          const r = cfg.a.r + (cfg.b.r - cfg.a.r)*t;
+          const g1= cfg.a.g + (cfg.b.g - cfg.a.g)*t;
+          const b = cfg.a.b + (cfg.b.b - cfg.a.b)*t;
+          col.setX(i, r); col.setY(i, g1); col.setZ(i, b);
+        }
+        col.needsUpdate = true;
+        cloud.material.vertexColors = true;
+      }
+      // let theme chip reflect style
+      const chip = document.getElementById('m-mode');
+      if (chip) chip.textContent = `Mode — ${cfg.label}`;
+    }
+
+    function inferStyle(p){
+      const s = p.toLowerCase();
+      // palettes (r,g,b in 0..1)
+      const C = (hex)=>new THREE_.Color(hex);
+      const A = C('#6bdc7a'), B = C('#1e6a37');        // grass
+      const R1= C('#8d8d93'), R2=C('#333338');         // rock
+      const W1= C('#56a7e6'), W2=C('#0a2749');         // water
+      const F1= C('#fb6aa9'), F2=C('#f6e85a');         // flower
+      const N1= C('#a6c8ff'), N2=C('#1b3f66');         // neon city/sky
+      const toRGB=(c)=>({r:c.r,g:c.g,b:c.b});
+      let label='Custom', a=N1, b=N2, mode='gradient';
+      if (/(grass|meadow|field|forest|green)/.test(s)){ label='Grass'; a=A; b=B; }
+      else if (/(rock|stone|canyon|mountain|desert)/.test(s)){ label='Rock'; a=R1; b=R2; }
+      else if (/(water|ocean|sea|lake|wave|river)/.test(s)){ label='Water'; a=W1; b=W2; }
+      else if (/(flower|bloom|garden|petal)/.test(s)){ label='Floral'; a=F1; b=F2; }
+      else if (/(city|neon|cyber|tower|building)/.test(s)){ label='Neon'; a=N1; b=N2; }
+      if (/noise|grain|speck|sparkle/.test(s)) mode='noise';
+      // scan current cloud bounds to set y-range
+      const bb = computeBounds();
+      return { label, a:toRGB(a), b:toRGB(b), yMin:bb.min.y, yMax:bb.max.y, mode };
+    }
+
+    function hash32(str){
+      let h=2166136261>>>0;
+      for (let i=0;i<str.length;i++){ h^=str.charCodeAt(i); h=Math.imul(h,16777619); }
+      return h>>>0;
+    }
+    function mulberry32(a){ return function(){ let t = (a += 0x6D2B79F5); t = Math.imul(t ^ t >>> 15, t | 1); t ^= t + Math.imul(t ^ t >>> 7, t | 61); return ((t ^ t >>> 14) >>> 0) / 4294967296; }; }
+
+    // ---------- UI helpers (all additive, no HTML rewrite required) ----------
+    function ensurePlayButton(){
+      let btn = document.getElementById('play-fp');
+      if (!btn){
+        // Fallback: inject if missing
+        const right = document.querySelector('.brand .right');
+        if (right){
+          btn = document.createElement('button');
+          btn.className='btn'; btn.id='play-fp'; btn.title='Enter first-person explore';
+          btn.textContent='▶ Explore';
+          // insert after fullscreen button if present
+          const fs = document.getElementById('toggle-fs');
+          fs?.insertAdjacentElement('afterend', btn) || right.appendChild(btn);
+        }
+      }
+      return btn;
+    }
+
+    function ensureStyleControls(){
+      const panel = document.querySelector('#controls-rail .controls');
+      if (!panel) return null;
+      // Only add once
+      if (document.getElementById('stylePrompt')) {
+        return { input: document.getElementById('stylePrompt'), apply: document.getElementById('applyStyle') };
+      }
+      const wrap = document.createElement('div');
+      wrap.className='ctrl'; wrap.title='Live recolor point clouds by prompt (e.g., "lush grass", "rocky canyon", "neon city")';
+      wrap.innerHTML = `
+        <label>Style Prompt</label>
+        <input id="stylePrompt" type="text" placeholder="e.g. lush grass, neon city, rocky canyon" autocomplete="off">
+        <button class="btn" id="applyStyle" type="button">Apply</button>
+      `;
+      panel.appendChild(wrap);
+      return { input: wrap.querySelector('#stylePrompt'), apply: wrap.querySelector('#applyStyle') };
+    }
+
+    // ESC exits explore (PointerLock handles most, but ensure UI toggles)
+    document.addEventListener('keydown', (e)=>{
+      if (e.key === 'Escape' && controlsFP.isLocked) { exitFP(); }
+    });
+  });
+})();

--- a/studio.html
+++ b/studio.html
@@ -124,11 +124,17 @@
 
       /* Reduced motion */
       @media (prefers-reduced-motion: reduce){ *{ animation: none !important; transition: none !important; } }
+      /* --- First-person HUD (non-invasive) --- */
+      .fp-hud{position:absolute;inset:0;pointer-events:none;display:none;place-items:center}
+      .fp-hud.on{display:grid}
+      .fp-cross{width:12px;height:12px;border:2px solid rgba(255,255,255,.9);border-radius:50%}
+      .fp-hint{position:absolute;bottom:16px;left:50%;transform:translateX(-50%);font-size:12px;color:var(--muted);background:rgba(0,0,0,.35);padding:6px 10px;border-radius:6px}
     </style>
 
     <!-- three.js r128 (kept for FBXLoader compatibility) -->
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/PointerLockControls.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/FBXLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/OBJLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/libs/inflate.min.js"></script>
@@ -141,6 +147,7 @@
         <div class="right">
           <a class="btn" id="home-btn" href="index.html" title="Home">⌂</a>
           <button class="btn desktop-fs-btn" id="toggle-fs" title="Toggle fullscreen (F / dbl‑click)">⤢</button>
+          <button class="btn" id="play-fp" title="Enter first-person explore">▶ Explore</button>
           <button class="btn" id="toggle-log" title="Show/Hide log">≡</button>
           <button class="btn" id="toggle-metrics" title="Show/Hide metrics">Σ</button>
           <div class="seg" role="group" aria-label="Theme">
@@ -169,6 +176,10 @@
             <div class="chip" id="m-status">Status — Init…</div>
           </div>
           <canvas id="btc-hash-canvas" aria-label="BTC hash visualization"></canvas>
+          <div id="fp-hud" class="fp-hud" aria-hidden="true">
+            <div class="fp-cross"></div>
+            <div class="fp-hint">WASD to move • Space to jump • Shift to run • Esc to exit</div>
+          </div>
           <div class="legend" id="btc-legend" aria-live="polite">
             <span id="btc-price">Price: Loading...</span>
             <span id="btc-time">Time: Loading...</span>
@@ -696,6 +707,7 @@
           const cp = $('camera-pos');
           if (cp) cp.textContent = `Pos: ${camera.position.x.toFixed(2)},${camera.position.y.toFixed(2)},${camera.position.z.toFixed(2)}`;
         }
+        document.dispatchEvent(new CustomEvent('quantumi:frame', { detail: { now: performance.now() } }));
         renderer.render(scene, camera);
       }
 
@@ -967,7 +979,13 @@
         // Metrics bootstrap
         updateMetrics();
         setInterval(updateMetrics, 60_000);
+        window.QUANTUMI = {
+          get scene(){ return scene; }, get camera(){ return camera; }, get renderer(){ return renderer; },
+          get controls(){ return controls; }, get dotClouds(){ return dotClouds; },
+          functions: { updateHashCloud, layoutFromHash, drawOriginalFromMarket, clearClouds }
+        };
       });
     </script>
+    <script type="module" src="./enhance.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add pointer lock controls and first-person explore button
- expose per-frame hooks and QUANTUMI global for extensions
- add enhancement script enabling explore mode and style recoloring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a04b311d80832a848c6774fd9dfd1f