### PR TITLE
Align login button style and enable Studio explore mode

### DIFF
--- a/enhance.js
+++ b/enhance.js
@@ -154,6 +154,8 @@
       controlsFP.unlock();
     }
 
+    window.enterFP = enterFP;
+
     controlsFP.addEventListener('lock', ()=>{
       active = true;
       hud?.classList.add('on');

--- a/frontend/enhance.js
+++ b/frontend/enhance.js
@@ -156,6 +156,8 @@
       if (document.fullscreenElement) document.exitFullscreen?.();
     }
 
+    window.enterFP = enterFP;
+
     controlsFP.addEventListener('lock', ()=>{
       active = true;
       hud?.classList.add('on');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2278,19 +2278,21 @@
                         margin-left: 0.5rem;
                     }
                     .login-btn {
-                        background: #fff;
-                        color: #000;
+                        background: #111;
+                        color: #fff;
                         font-weight: 600;
-                        border: none;
+                        border: 1px solid #00FF00;
                         border-radius: 6px;
                         font-size: 1.15em;
                         padding: 0.7em;
                         cursor: pointer;
                         transition: background 0.18s, color 0.18s;
+                        min-width: 44px;
+                        min-height: 44px;
                     }
                     .login-btn:hover,
                     .login-btn:focus {
-                        background: #35e1ad;
+                        background: #00FF00;
                         color: #111;
                     }
                     .buttons {

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -147,7 +147,7 @@
         <div class="right">
             <a class="btn" id="home-btn" href="index.html" title="Home">⌂</a>
             <button class="btn desktop-fs-btn" id="toggle-fs" title="Toggle fullscreen (F / dbl‑click)">⤢</button>
-            <button class="btn" id="play-fp" title="Enter first-person explore">▶ Explore</button>
+            <button class="btn" id="play-fp" title="Enter first-person explore" onclick="window.enterFP && window.enterFP()">▶ Explore</button>
             <button class="btn" id="toggle-log" title="Show/Hide log">≡</button>
           <button class="btn" id="toggle-metrics" title="Show/Hide metrics">Σ</button>
           <div class="seg" role="group" aria-label="Theme">

--- a/studio.html
+++ b/studio.html
@@ -147,7 +147,7 @@
         <div class="right">
           <a class="btn" id="home-btn" href="index.html" title="Home">⌂</a>
           <button class="btn desktop-fs-btn" id="toggle-fs" title="Toggle fullscreen (F / dbl‑click)">⤢</button>
-          <button class="btn" id="play-fp" title="Enter first-person explore">▶ Explore</button>
+          <button class="btn" id="play-fp" title="Enter first-person explore" onclick="window.enterFP && window.enterFP()">▶ Explore</button>
           <button class="btn" id="toggle-log" title="Show/Hide log">≡</button>
           <button class="btn" id="toggle-metrics" title="Show/Hide metrics">Σ</button>
           <div class="seg" role="group" aria-label="Theme">


### PR DESCRIPTION
## Summary
- Match index page login button styling to login page's dark theme with neon green hover
- Expose global `enterFP` and trigger it from the Studio page's Explore button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c21e9f74832a9cb3874a9f4037df