### PR TITLE
Fix mobile header buttons and enhance explore init

### DIFF
--- a/enhance.js
+++ b/enhance.js
@@ -1,13 +1,14 @@
 // QUANTUMI add-on: first-person Explore mode + generative style recoloring (non-destructive)
 // Works with three r128. Depends on window.QUANTUMI (exposed by the patch) and PointerLockControls.
 
+
 (function(){
   const wait = (cond, t=50) => new Promise(res=>{
     const tick=()=>cond()?res():setTimeout(tick,t);
     tick();
   });
 
-  document.addEventListener('DOMContentLoaded', async ()=>{
+  async function init(){
     await wait(()=>window.QUANTUMI && window.THREE);
 
     const Q = window.QUANTUMI;
@@ -279,5 +280,11 @@
     document.addEventListener('keydown', (e)=>{
       if (e.key === 'Escape' && controlsFP.isLocked) { exitFP(); }
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();

--- a/studio.html
+++ b/studio.html
@@ -70,7 +70,7 @@
       .desktop-fs-btn{ display:inline-flex; }
 
       @media (max-width:1180px){ main{ grid-template-columns:1fr; grid-template-areas:'stage' 'controls' 'aside'; } }
-      @media (max-width:640px){ .mobile-fs-btn{ display:inline-flex; } .desktop-fs-btn{ display:none; } main{ padding:8px; gap:8px; grid-template-areas:'stage' 'controls' 'aside'; } #stagePanel{ min-height:68dvh; } .brand{ flex-direction:column; align-items:flex-start; } .right{ width:100%; justify-content:flex-start; overflow-x:auto; } }
+      @media (max-width:640px){ .mobile-fs-btn{ display:inline-flex; } .desktop-fs-btn{ display:none; } main{ padding:8px; gap:8px; grid-template-areas:'stage' 'controls' 'aside'; } #stagePanel{ min-height:68dvh; } .brand{ flex-direction:column; align-items:flex-start; } .right{ width:100%; justify-content:flex-start; overflow-x:auto; flex-wrap:nowrap; } .btn{ padding:8px 12px; } }
 
       .aside{ grid-area:aside; display:flex; flex-direction:column; gap:10px; overflow:auto; padding:10px; scrollbar-color:#333 #111; }
       .card{ background:var(--panel-bg); border:1px solid var(--panel-brd); border-radius:14px; padding:12px; }


### PR DESCRIPTION
## Summary
- keep studio header buttons tidy on small screens by constraining them to a single scrolling row and reducing padding
- ensure `enhance.js` initializes even when loaded after `DOMContentLoaded`, restoring Explore mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfbbe7bc832a92855dea0f72d808