### PR TITLE
Ensure modules contain overflow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2456,7 +2456,10 @@
                         #exch-spikes-module .spikes-list {
                                 display: grid;
                                 gap: 6px;
-                                overflow-x: auto;
+                                overflow-x: hidden;
+                                overflow-y: auto;
+                                max-height: 50vh;
+                                padding-right: 4px;
                         }
                         #exch-spikes-module .spike-row {
                                 border: 1px solid var(--panel-brd);
@@ -2492,6 +2495,7 @@
                                 background: var(--panel-bg);
                                 padding: 8px;
                                 box-sizing: border-box;
+                                overflow: hidden;
                         }
                         @media (max-width: 768px) {
                                 #exch-spikes-module .exch-grid {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -18,6 +18,8 @@ section {
   padding: 1rem;
   border: 1px solid rgba(0, 255, 0, 0.1);
   border-radius: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 ul {
@@ -131,4 +133,14 @@ button:active {
 
 .loader {
   padding: 1rem;
+}
+
+/* Keep dynamic data contained within modules */
+.module-content {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: auto;
+  box-sizing: border-box;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- keep dynamic module data contained by adding overflow and max-height styles
- prevent exchange spikes module from spilling out of its boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11a0a2050832a9747f426b6dac3da