### PR TITLE
Ensure modules contain overflow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2444,7 +2444,9 @@
                                 grid-template-columns: 1.1fr 1fr;
                                 gap: 14px;
                                 width: 100%;
+                                max-width: 100%;
                                 box-sizing: border-box;
+                                overflow: hidden;
                         }
                         #exch-spikes-module .exch-panel {
                                 border: 1px solid var(--panel-brd);
@@ -2452,11 +2454,20 @@
                                 background: var(--panel-bg);
                                 padding: 10px;
                                 box-sizing: border-box;
+                                width: 100%;
+                                max-width: 100%;
+                                overflow: hidden;
                         }
                         #exch-spikes-module .spikes-list {
                                 display: grid;
                                 gap: 6px;
-                                overflow-x: auto;
+                                overflow-x: hidden;
+                                overflow-y: auto;
+                                max-height: 50vh;
+                                padding-right: 4px;
+                                width: 100%;
+                                max-width: 100%;
+                                box-sizing: border-box;
                         }
                         #exch-spikes-module .spike-row {
                                 border: 1px solid var(--panel-brd);
@@ -2465,6 +2476,7 @@
                                 padding: 8px;
                                 cursor: pointer;
                                 width: 100%;
+                                max-width: 100%;
                                 box-sizing: border-box;
                                 overflow-wrap: anywhere;
                         }
@@ -2492,6 +2504,7 @@
                                 background: var(--panel-bg);
                                 padding: 8px;
                                 box-sizing: border-box;
+                                overflow: hidden;
                         }
                         @media (max-width: 768px) {
                                 #exch-spikes-module .exch-grid {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -18,6 +18,8 @@ section {
   padding: 1rem;
   border: 1px solid rgba(0, 255, 0, 0.1);
   border-radius: 8px;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 ul {
@@ -131,4 +133,14 @@ button:active {
 
 .loader {
   padding: 1rem;
+}
+
+/* Keep dynamic data contained within modules */
+.module-content {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  box-sizing: border-box;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- keep dynamic module data contained by adding overflow and max-width styles
- prevent exchange spikes module from spilling out of its boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11a0a2050832a9747f426b6dac3da