### PR TITLE
feat: add runner and world builder

### DIFF
--- a/frontend/game-ext.js
+++ b/frontend/game-ext.js
@@ -1,0 +1,156 @@
+// QUANTUMI game extensions: runner and world builder
+// This module hooks into studio.html via window.QUANTUMI and custom events.
+
+(function(){
+  const q = window.QUANTUMI;
+  if(!q) return;
+  const scene = q.scene;
+  const camera = q.camera;
+  const controls = q.controls;
+
+  // --- Runner ---------------------------------------------------------------
+  const runnerToggle = document.getElementById('runner-toggle');
+  const runnerAttach = document.getElementById('runner-attach');
+  const runnerFPV = document.getElementById('runner-fpv');
+  const runnerSpeedEl = document.getElementById('runner-speed');
+  let runnerSpeed = parseFloat(runnerSpeedEl?.value || '1.2');
+  let runner, runnerCurve = null, runnerDist = 0;
+  let runnerActive = false, chaseCam = false, fpv = false;
+
+  runnerSpeedEl?.addEventListener('input', e=>{ runnerSpeed = parseFloat(e.target.value); });
+
+  function buildCurve(){
+    const pts = q.path || [];
+    if(pts.length<2) return null;
+    runnerCurve = new THREE.CatmullRomCurve3(pts);
+    runnerDist = 0;
+    return runnerCurve;
+  }
+
+  function startRunner(){
+    if(runnerActive) return;
+    if(!buildCurve()) return;
+    const geom = new THREE.SphereGeometry(0.35,16,16);
+    const mat = new THREE.MeshStandardMaterial({ color:0xffaa00, emissive:0x331100 });
+    runner = new THREE.Mesh(geom,mat);
+    scene.add(runner);
+    runnerActive = true;
+    runnerToggle.textContent = 'Stop Runner';
+    runnerToggle.setAttribute('aria-pressed','true');
+  }
+  function stopRunner(){
+    if(!runnerActive) return;
+    scene.remove(runner);
+    runner = null;
+    runnerActive = false;
+    runnerToggle.textContent = 'Start Runner';
+    runnerToggle.setAttribute('aria-pressed','false');
+    detachCam();
+  }
+  function toggleRunner(){ runnerActive ? stopRunner() : startRunner(); }
+
+  function toggleAttach(){
+    chaseCam = !chaseCam;
+    runnerAttach.setAttribute('aria-pressed', String(chaseCam));
+    if(!chaseCam) fpv=false;
+    runnerFPV.setAttribute('aria-pressed', String(fpv));
+    controls.enabled = !fpv;
+  }
+  function toggleFPV(){
+    fpv = !fpv; if(fpv) chaseCam=true; runnerFPV.setAttribute('aria-pressed', String(fpv));
+    runnerAttach.setAttribute('aria-pressed', String(chaseCam));
+    controls.enabled = !fpv;
+  }
+  function detachCam(){ chaseCam=false; fpv=false; runnerAttach.setAttribute('aria-pressed','false'); runnerFPV.setAttribute('aria-pressed','false'); controls.enabled=true; }
+
+  runnerToggle?.addEventListener('click', toggleRunner);
+  runnerAttach?.addEventListener('click', toggleAttach);
+  runnerFPV?.addEventListener('click', toggleFPV);
+
+  document.addEventListener('keydown', e=>{
+    if(e.target && ['INPUT','TEXTAREA'].includes(e.target.tagName)) return;
+    const k = e.key.toLowerCase();
+    if(k==='r') toggleRunner();
+    if(k==='c') toggleAttach();
+    if(k==='f') toggleFPV();
+  });
+
+  document.addEventListener('quantumi:cloud', ()=>{ if(runnerActive) buildCurve(); });
+
+  document.addEventListener('quantumi:tick', e=>{
+    const dt = e.detail.dt;
+    if(!runnerActive || !runnerCurve || !runner) return;
+    runnerDist += runnerSpeed * dt;
+    const len = runnerCurve.getLength();
+    let t = runnerDist / len;
+    if(t>1){ t=1; runnerActive=false; }
+    const pos = runnerCurve.getPoint(t);
+    const tan = runnerCurve.getTangent(t);
+    runner.position.copy(pos);
+    runner.lookAt(pos.clone().add(tan));
+    if(chaseCam){
+      if(fpv){
+        camera.position.copy(pos.clone().add(new THREE.Vector3(0,0.2,0)));
+        camera.lookAt(pos.clone().add(tan));
+      }else{
+        const behind = pos.clone().add(tan.clone().normalize().multiplyScalar(-3)).add(new THREE.Vector3(0,1,0));
+        camera.position.lerp(behind,0.1);
+        controls.target.copy(pos);
+        controls.update();
+      }
+    }
+  });
+
+  // --- World Builder -------------------------------------------------------
+  const promptEl = document.getElementById('worldPrompt');
+  const buildBtn = document.getElementById('build-world');
+  const resetBtn = document.getElementById('reset-world');
+  const modeChip = document.querySelectorAll('#m-mode')[1] || document.getElementById('m-mode');
+  const worldObjects = [];
+
+  function clearWorld(){
+    while(worldObjects.length){ scene.remove(worldObjects.pop()); }
+    modeChip && (modeChip.textContent = 'Mode — World(none)');
+  }
+
+  function buildWorld(){
+    const prompt = (promptEl.value||'').toLowerCase();
+    clearWorld();
+    if(!prompt) return;
+    if(prompt.includes('neon')){
+      const plane = new THREE.Mesh(new THREE.PlaneGeometry(40,40), new THREE.MeshBasicMaterial({color:0x050505}));
+      plane.rotation.x = -Math.PI/2; scene.add(plane); worldObjects.push(plane);
+      for(let i=0;i<60;i++){
+        const h = Math.random()*4+1;
+        const box = new THREE.Mesh(new THREE.BoxGeometry(0.5,h,0.5), new THREE.MeshStandardMaterial({color:0x111111, emissive:new THREE.Color(`hsl(${Math.random()*360},80%,60%)`)}));
+        box.position.set((Math.random()-0.5)*30, h/2, (Math.random()-0.5)*30);
+        scene.add(box); worldObjects.push(box);
+      }
+    }else if(prompt.includes('grass')){
+      const plane = new THREE.Mesh(new THREE.PlaneGeometry(40,40,32,32), new THREE.MeshLambertMaterial({color:0x228b22}));
+      plane.rotation.x = -Math.PI/2; scene.add(plane); worldObjects.push(plane);
+    }else if(prompt.includes('mountain')){
+      const geo = new THREE.PlaneGeometry(40,40,64,64);
+      geo.rotateX(-Math.PI/2);
+      for(let i=0;i<geo.attributes.position.count;i++){
+        const y = Math.random()*6; geo.attributes.position.setY(i, y);
+      }
+      geo.computeVertexNormals();
+      const mesh = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({color:0x888888}));
+      scene.add(mesh); worldObjects.push(mesh);
+    }else if(prompt.includes('alien') || prompt.includes('crystal')){
+      const plane = new THREE.Mesh(new THREE.PlaneGeometry(40,40), new THREE.MeshBasicMaterial({color:0x000}));
+      plane.rotation.x = -Math.PI/2; scene.add(plane); worldObjects.push(plane);
+      for(let i=0;i<30;i++){
+        const h = Math.random()*3+2;
+        const crystal = new THREE.Mesh(new THREE.ConeGeometry(0.5,h,6), new THREE.MeshStandardMaterial({color:new THREE.Color(`hsl(${Math.random()*360},70%,70%)`), emissive:0x222222, transparent:true, opacity:0.85}));
+        crystal.position.set((Math.random()-0.5)*30, h/2, (Math.random()-0.5)*30);
+        scene.add(crystal); worldObjects.push(crystal);
+      }
+    }
+    modeChip && (modeChip.textContent = `Mode — World(${prompt||'none'})`);
+  }
+
+  buildBtn?.addEventListener('click', buildWorld);
+  resetBtn?.addEventListener('click', clearWorld);
+})();

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -240,11 +240,27 @@
                 <input id="modelColor" type="color" value="#22d3ee" />
               </div>
               <div class="ctrl" title="Skip vertices for huge meshes to keep FPS high.">
-                <label>Model Sampling (every n-th)</label>
-                <input id="modelStride" type="number" min="1" step="1" value="1" />
-              </div>
+            <label>Model Sampling (every n-th)</label>
+            <input id="modelStride" type="number" min="1" step="1" value="1" />
+            </div>
             </div>
             <div id="modelStatus" class="text-xs opacity-80 mt-1"></div>
+          </div>
+          <div class="ctrl" title="Autonomous runner that climbs the current BTC path.">
+            <label>Runner</label>
+            <button class="btn" id="runner-toggle" aria-pressed="false">Start Runner</button>
+            <button class="btn" id="runner-attach" aria-pressed="false">Attach Cam</button>
+            <button class="btn" id="runner-fpv" aria-pressed="false">First-Person (FPV)</button>
+            <input class="w-full" type="range" id="runner-speed" min="0.2" max="5" step="0.1" value="1.2" />
+            <small>Hotkeys: R=run, C=chase, F=first-person</small>
+          </div>
+
+          <div class="ctrl" title="Turn clouds into worlds">
+            <label>World Builder Prompt</label>
+            <input id="worldPrompt" type="text" placeholder="e.g., neon city, grass field, mountainous terrain…" />
+            <button class="btn" id="build-world">Build World</button>
+            <button class="btn" id="reset-world">Reset World</button>
+            <div id="m-mode" class="chip">Mode — World(none)</div>
           </div>
           <div class="ctrl" title="Playback & camera">
             <label>Camera</label>
@@ -280,6 +296,7 @@
     </footer>
 
     <script src="quantumi-logo.js"></script>
+    <script>let lastPathPoints = [];</script>
     <script>
       // --- Theme toggle (Light / Dark). Remembers choice. iOS-ready light.
       (function initTheme(){
@@ -451,17 +468,19 @@
         const recent = prices.slice(-10).map(p=>p[1]); const volatility = ((Math.max(...recent)-Math.min(...recent))/latestPrice)*100;
         const cloudColorHex = getThemeColor(volatility, latestVolume, minVolume, maxVolume); const cloudColor = new THREE.Color(cloudColorHex);
         const pointsPerCloud = parseInt($('density').value,10);
-        const positions=[]; const colors=[]; const jitter=0.6;
+        const positions=[]; const colors=[]; const jitter=0.6; const centers=[];
         for(let i=0;i<prices.length;i++){
           const t = timestamps[i]; const price = prices[i][1]; const vol = volumes[i][1];
           const z = ((t-minTime)/(maxTime-minTime))*20-10;
           const x = ((price-minPrice)/(maxPrice-minPrice))*20-10;
           const y = ((vol-minVolume)/(maxVolume-minVolume))*20-10;
+          centers.push(new THREE.Vector3(x,y,z));
           for(let j=0;j<pointsPerCloud;j++){
             positions.push(x+(Math.random()-.5)*jitter, y+(Math.random()-.5)*jitter, z+(Math.random()-.5)*jitter);
             colors.push(cloudColor.r, cloudColor.g, cloudColor.b);
           }
         }
+        lastPathPoints = centers;
         const count = positions.length/3;
         let cloud;
         if (customGeometry) {
@@ -486,7 +505,7 @@
       }
 
       function layoutFromHash(hash, mapping){
-        const vals = Array.from(hash).map(ch=>parseInt(ch,16)); const N = 256; const positions=[]; const colors=[];
+        const vals = Array.from(hash).map(ch=>parseInt(ch,16)); const N = 256; const positions=[]; const colors=[]; const pathPts=[];
         const base = new THREE.Color(themes.original[dotClouds.length % themes.original.length]);
         for(let i=0;i<N;i++){
           const v = vals[i % vals.length] / 15; let x,y,z;
@@ -494,8 +513,9 @@
           else if(mapping==='sphere'){ const phi=Math.acos(1-(2*(i+.5))/N); const theta=Math.PI*(1+Math.sqrt(5))*(i+v); const R=6*(.6+.4*v); x=R*Math.sin(phi)*Math.cos(theta); y=R*Math.sin(phi)*Math.sin(theta); z=R*Math.cos(phi); }
           else if(mapping==='helix'){ const a=(i/N)*Math.PI*8; x=Math.cos(a)*5; y=Math.sin(a)*5; z=(i/N)*20-10+(v-.5); }
           else{ const a=i*.28, r=2+v*4; x=Math.cos(a)*r; y=Math.sin(a)*r; z=(i/N)*16-8; }
-          positions.push(x,y,z); colors.push(base.r, base.g, base.b);
+          positions.push(x,y,z); colors.push(base.r, base.g, base.b); pathPts.push(new THREE.Vector3(x,y,z));
         }
+        lastPathPoints = pathPts;
         const count = positions.length/3;
         let cloud;
         if (customGeometry) {
@@ -709,15 +729,19 @@
       }
 
       // --- Controls & lifecycle --------------------------------------------
+      let __last = performance.now();
       function animate() {
         requestAnimationFrame(animate);
+        const __now = performance.now();
+        const dt = (__now - __last)/1000; __last = __now;
+        document.dispatchEvent(new CustomEvent('quantumi:tick',{ detail:{ dt } }));
         controls && controls.update();
         handleGamepadInput();
         if (camera) {
           const cp = $('camera-pos');
           if (cp) cp.textContent = `Pos: ${camera.position.x.toFixed(2)},${camera.position.y.toFixed(2)},${camera.position.z.toFixed(2)}`;
         }
-        document.dispatchEvent(new CustomEvent('quantumi:frame', { detail: { now: performance.now() } }));
+        document.dispatchEvent(new CustomEvent('quantumi:frame', { detail: { now: __now } }));
         renderer.render(scene, camera);
       }
 
@@ -992,10 +1016,12 @@
         window.QUANTUMI = {
           get scene(){ return scene; }, get camera(){ return camera; }, get renderer(){ return renderer; },
           get controls(){ return controls; }, get dotClouds(){ return dotClouds; },
+          get path(){ return lastPathPoints; },
           functions: { updateHashCloud, layoutFromHash, drawOriginalFromMarket, clearClouds }
         };
       });
     </script>
     <script type="module" src="./enhance.js"></script>
+    <script type="module" src="./game-ext.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add runner controls to climb current BTC path and support camera attach and FPV
- expose path points and tick events for extensions
- add world-builder prompt with preset environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f3f0ed48832a82bbfb8f79e5c710