### PR TITLE
feat: add AI map generator and world build

### DIFF
--- a/frontend/ai-mapgen.js
+++ b/frontend/ai-mapgen.js
@@ -1,0 +1,14 @@
+export class AIMapGen {
+  constructor({ baseURL }){
+    this.baseURL = baseURL || (location.origin.replace(/^http/,'http') + ':8787');
+  }
+  async generate({ seed='btc', prompt='grass cliffs neon city', cols=6, rows=6, size=12 }){
+    const r = await fetch(this.baseURL + '/api/mapgen', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ seed, prompt, cols, rows, size })
+    });
+    if (!r.ok) throw new Error('mapgen failed ' + r.status);
+    return r.json();
+  }
+}
+export function descLabel(d){ const g=d.grid; return `Map v${d.version} • ${g.cols}x${g.rows}@${g.size} • ${d.seed} • “${d.prompt}”`; }

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -1028,5 +1028,11 @@
     <script type="module" src="./game-settings.js"></script>
     <!-- FPV Explore module -->
     <script type="module" src="./fpv-explore.js"></script>
+    <script type="module" src="./ai-mapgen.js"></script>
+    <script type="module" src="./ui-ai-map.js"></script>
+    <script type="module">
+      import { attachAIMapUI } from './ui-ai-map.js';
+      window.addEventListener('load', attachAIMapUI);
+    </script>
   </body>
 </html>

--- a/frontend/ui-ai-map.js
+++ b/frontend/ui-ai-map.js
@@ -1,0 +1,48 @@
+import { AIMapGen, descLabel } from './ai-mapgen.js';
+import { buildWorld } from './worldgen-br.js';
+
+export function attachAIMapUI(){
+  const Q = window.QUANTUMI;
+  const panel = document.createElement('div');
+  panel.id='ai-panel';
+  panel.style.cssText='position:absolute;left:10px;bottom:10px;z-index:41;background:rgba(0,0,0,.45);color:#fff;padding:10px;border-radius:10px;font:12px system-ui;display:flex;gap:6px;align-items:center;flex-wrap:wrap;';
+  panel.innerHTML = `
+    <input id="ai-seed" placeholder="seed" value="btc" style="width:90px">
+    <input id="ai-prompt" placeholder="world prompt" value="grass cliffs neon city" style="width:200px">
+    <select id="ai-size">
+      <option value="6x6x12" selected>6x6 @12</option>
+      <option value="8x8x10">8x8 @10</option>
+      <option value="10x10x8">10x10 @8</option>
+    </select>
+    <button id="ai-gen">Generate</button>
+    <span id="ai-status"></span>
+  `;
+  document.body.appendChild(panel);
+
+  const $ = (id)=> document.getElementById(id);
+  async function generate(){
+    const [cols,rows,size] = $('#ai-size').value.split('x').map(Number);
+    const gen = new AIMapGen({});
+    $('#ai-status').textContent = '…generating';
+    try{
+      const desc = await gen.generate({
+        seed: $('#ai-seed').value.trim() || 'btc',
+        prompt: $('#ai-prompt').value.trim() || 'terrain',
+        cols, rows, size
+      });
+      buildWorld({ scene: Q.scene, mapDesc: desc });
+      window.QUANTUMI = window.QUANTUMI || {}; window.QUANTUMI.lastMap = desc;
+      $('#ai-status').textContent = descLabel(desc);
+    }catch(e){
+      $('#ai-status').textContent = 'error: ' + e.message;
+      console.error(e);
+    }
+  }
+  $('#ai-gen').onclick = generate;
+
+  // Command hook
+  window.QUANTUMI = window.QUANTUMI || {}; window.QUANTUMI.commands = window.QUANTUMI.commands || { list:[], run:(c)=>{} };
+  const run0 = window.QUANTUMI.commands.run.bind(window.QUANTUMI.commands);
+  window.QUANTUMI.commands.run = (cmd,arg)=> cmd==='ai-generate' ? generate() : run0(cmd,arg);
+  window.QUANTUMI.commands.list.push(['AI: Generate Map','ai-generate']);
+}

--- a/frontend/worldgen-br.js
+++ b/frontend/worldgen-br.js
@@ -1,0 +1,68 @@
+/* Add a new entry-point that accepts a MapDescriptor.
+   Keep your existing point-cloud based builder as fallback.
+*/
+const THREE = window.THREE;
+
+export function buildWorldFromDescriptor(scene, desc){
+  // Remove old
+  scene.getObjectByName('BRWorld')?.removeFromParent();
+  const group = new THREE.Group(); group.name='BRWorld';
+
+  const { cols, rows, size } = desc.grid;
+  const groundMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(desc.materials?.ground||'#2b3a2e'), roughness:0.95, metalness:0.02
+  });
+
+  // Floor tiles + per-chunk instancing
+  for (let j=0;j<rows;j++){
+    for (let i=0;i<cols;i++){
+      const c = desc.chunks.find(x=>x.i===i && x.j===j);
+      const baseY = (c?.elev||0) * 1.2;
+      const tile = new THREE.Mesh(new THREE.BoxGeometry(size, 0.12, size), groundMat);
+      tile.position.set(i*size + size/2, baseY, j*size + size/2);
+      tile.receiveShadow = true; group.add(tile);
+
+      const { mesh, colorize } = instForBiome(c?.biome || 'terrain', Math.floor(60 * Math.max(0.1,(c?.density||0.5))));
+      const dummy = new THREE.Object3D(); const col = new THREE.Color();
+      for (let k=0;k<mesh.count;k++){
+        dummy.position.set(
+          tile.position.x + (Math.random()-0.5)*(size*0.9),
+          baseY + (Math.random()-0.5)*0.6,
+          tile.position.z + (Math.random()-0.5)*(size*0.9)
+        );
+        dummy.rotation.y = Math.random()*Math.PI*2;
+        dummy.scale.setScalar(0.6 + Math.random()*0.9);
+        dummy.updateMatrix(); mesh.setMatrixAt(k, dummy.matrix);
+        col.setHex(colorize()); mesh.setColorAt(k, col);
+      }
+      mesh.instanceMatrix.needsUpdate=true; mesh.instanceColor.needsUpdate=true;
+      group.add(mesh);
+    }
+  }
+
+  // POIs
+  (desc.pois||[]).forEach(p=>{
+    const m = new THREE.Mesh(new THREE.CylinderGeometry(0.35,0.35,0.1,16),
+      new THREE.MeshStandardMaterial({ color: p.type==='loot'?0xffd54f:0x80eaff, emissive:0x112233 }));
+    m.position.set(p.x, p.y, p.z); group.add(m);
+  });
+
+  scene.add(group);
+  return group;
+
+  function instForBiome(biome, count){
+    const mat = (opts)=> new THREE.MeshStandardMaterial({ roughness:opts.r||0.6, metalness:opts.m||0.2, vertexColors:true, emissive:opts.e||0x000000 });
+    if (biome==='city')   return { mesh:new THREE.InstancedMesh(new THREE.BoxGeometry(0.24,1,0.24),   mat({r:.55,m:.2}), count), colorize:()=> new THREE.Color().setHSL(0.58+Math.random()*0.03,0.12,0.68-Math.random()*0.22).getHex() };
+    if (biome==='desert') return { mesh:new THREE.InstancedMesh(new THREE.ConeGeometry(0.32,0.6,5),   mat({r:.8,m:.05}), count), colorize:()=> new THREE.Color().setHSL(0.10+Math.random()*0.02,0.55,0.65).getHex() };
+    if (biome==='ice')    return { mesh:new THREE.InstancedMesh(new THREE.BoxGeometry(0.3,0.3,0.3),   mat({r:.15,m:.6}), count), colorize:()=> new THREE.Color().setHSL(0.56+Math.random()*0.05,0.35,0.85).getHex() };
+    if (biome==='alien')  return { mesh:new THREE.InstancedMesh(new THREE.IcosahedronGeometry(0.22,0),mat({r:.25,m:.6,e:0x0b2f33}), count), colorize:()=> new THREE.Color().setHSL(0.52+Math.random()*0.15,0.85,0.55).getHex() };
+    if (biome==='grass')  return { mesh:new THREE.InstancedMesh(new THREE.ConeGeometry(0.06,0.25,6),  mat({r:.85,m:0}), count), colorize:()=> new THREE.Color().setHSL(0.36+Math.random()*0.05,0.8,0.45+Math.random()*0.1).getHex() };
+    return                 { mesh:new THREE.InstancedMesh(new THREE.BoxGeometry(0.24,0.24,0.24),      mat({r:.9,m:.05}), count), colorize:()=> new THREE.Color().setHSL(0.08+Math.random()*0.03,0.65,0.42+Math.random()*0.08).getHex() };
+  }
+}
+
+export function buildWorld(opts){
+  // Back-compat: if a MapDescriptor is passed, use it; else, keep your current code path.
+  if (opts.mapDesc) return buildWorldFromDescriptor(opts.scene, opts.mapDesc);
+  // … keep your existing point-cloud builder here unchanged …
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "multer": "^1.4.5-lts.1",
         "ngrok": "^4.3.0",
         "node-json-db": "^1.4.1",
+        "ws": "^8.15.1",
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5",
         "youtube-audio-stream": "0.0.6",

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -1,0 +1,120 @@
+/* Tiny WS relay (if you already had one, keep it) + /api/mapgen.
+   If OPENAI_API_KEY is provided, we call OpenAI Responses API (JSON schema).
+   Otherwise we emit a deterministic stub so the client always works.
+*/
+const http = require('http');
+const WebSocket = require('ws');
+const url = require('url');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 8787;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+
+const server = http.createServer(async (req,res)=>{
+  const { pathname } = url.parse(req.url, true);
+  if (pathname==='/health'){ res.writeHead(200); res.end('ok'); return; }
+
+  if (pathname==='/api/mapgen' && req.method==='POST'){
+    let body=''; for await (const c of req) body+=c;
+    let payload = {}; try{ payload = JSON.parse(body||'{}'); }catch{}
+    const seed = String(payload.seed || 'btc');
+    const prompt = String(payload.prompt || 'grass cliffs neon city');
+    const cols = Math.max(2, Math.min(64, parseInt(payload.cols||6,10)));
+    const rows = Math.max(2, Math.min(64, parseInt(payload.rows||6,10)));
+    const size = Math.max(4, Math.min(64, parseFloat(payload.size||12)));
+
+    if (OPENAI_API_KEY){
+      // OpenAI Responses API with JSON Schema (best reliability)
+      const schema = {
+        name: "MapDescriptor",
+        schema: {
+          type: "object", additionalProperties: false,
+          properties: {
+            version: { type: "integer", const: 1 },
+            seed: { type: "string" }, prompt: { type: "string" },
+            grid: { type: "object", additionalProperties:false,
+              properties: { cols:{type:"integer"}, rows:{type:"integer"}, size:{type:"number"} },
+              required:["cols","rows","size"]
+            },
+            chunks: { type:"array", minItems: cols*rows, maxItems: cols*rows,
+              items: { type:"object", additionalProperties:false,
+                properties:{ i:{type:"integer"}, j:{type:"integer"},
+                  biome:{type:"string", enum:["city","desert","ice","alien","grass","terrain"]},
+                  elev:{type:"number"}, density:{type:"number"} },
+                required:["i","j","biome","elev","density"]
+              }
+            },
+            pois: { type:"array",
+              items:{ type:"object", additionalProperties:false,
+                properties:{ x:{type:"number"}, y:{type:"number"}, z:{type:"number"},
+                  type:{type:"string", enum:["loot","jump","spawn","heal","objective"]} },
+                required:["x","y","z","type"]
+              }
+            },
+            materials:{ type:"object", additionalProperties:false,
+              properties:{ ground:{type:"string"}, accent:{type:"string"}, emissive:{type:"string"} },
+              required:["ground","accent","emissive"]
+            }
+          },
+          required:["version","seed","prompt","grid","chunks","pois","materials"]
+        }
+      };
+
+      const body = {
+        model: "gpt-4.1-mini",
+        input: [
+          { role:"system", content:"You are a map designer. Output ONLY valid MapDescriptor JSON." },
+          { role:"user", content:[{type:"text", text:
+`seed=${seed}
+prompt="${prompt}"
+grid: ${cols}x${rows} chunks, chunk size=${size}
+Rules:
+- Fill all ${cols*rows} chunks with coherent biomes.
+- elev ∈ [-1..1] (broad shape), density ∈ [0..1].
+- Place 6–12 POIs spread out; types loot/jump/spawn/heal/objective.
+- materials must match prompt aesthetics.`}]}
+        ],
+        response_format: { type:"json_schema", json_schema:schema }
+      };
+
+      try{
+        const r = await fetch("https://api.openai.com/v1/responses", {
+          method:"POST",
+          headers:{ "Authorization": 'Bearer ' + OPENAI_API_KEY, "Content-Type": "application/json" },
+          body: JSON.stringify(body)
+        });
+        if (!r.ok){ throw new Error(await r.text()); }
+        const data = await r.json();
+        const desc = data.output?.[0]?.content?.[0]?.json || data.output_parsed || data;
+        // enforce request params
+        desc.version = 1; desc.seed = seed; desc.prompt = prompt; desc.grid = { cols, rows, size };
+        res.writeHead(200,{"Content-Type":"application/json"}); res.end(JSON.stringify(desc)); return;
+      }catch(e){
+        console.error("mapgen openai error:", e.message);
+        // fallthrough to stub if AI fails
+      }
+    }
+
+    // Deterministic stub (no key or AI failure)
+    const chunks=[]; // simple noise
+    const n = (i,j)=>{ const h=crypto.createHash('sha256').update(`${seed}|${i}|${j}`).digest(); return h[0]/255; };
+    const classify=(p,x)=>/city|urban|mega/.test(p)?"city":/desert|dune|sand/.test(p)?"desert":/ice|snow|glacier/.test(p)?"ice":/alien|neon|crystal/.test(p)?"alien":/forest|grass|meadow|park/.test(p)?"grass":"terrain";
+    for(let j=0;j<rows;j++) for(let i=0;i<cols;i++){
+      const base = n(i,j); const biome = classify(prompt, base);
+      const elev = (n(i*3,j*3)-0.5)*2; const density = 0.5 + (n(i*7,j*7)-0.5);
+      chunks.push({ i,j, biome, elev, density });
+    }
+    const pois=[]; const cx=(cols*size)/2, cz=(rows*size)/2, R=Math.min(cx,cz)*0.7;
+    for (let k=0;k<8;k++){ const a= (k/8)*Math.PI*2; pois.push({ x:cx+Math.cos(a)*R, y:0.3, z:cz+Math.sin(a)*R, type: (k%2?'loot':'jump') }); }
+    const materials = { ground:'#2b3a2e', accent:'#4fd1c5', emissive:'#0b2f33' };
+    const desc = { version:1, seed, prompt, grid:{cols,rows,size}, chunks, pois, materials };
+    res.writeHead(200,{"Content-Type":"application/json"}); res.end(JSON.stringify(desc)); return;
+  }
+
+  // default reply
+  res.writeHead(200); res.end('dev relay / mapgen');
+});
+
+const wss = new WebSocket.Server({ server });
+wss.on('connection', (ws)=>{ ws.on('message',()=>{}); });
+server.listen(PORT, ()=> console.log('Dev server on', PORT, ' (POST /api/mapgen)'));


### PR DESCRIPTION
## Summary
- add development server with `/api/mapgen` for OpenAI-backed or stubbed map generation
- build worlds from MapDescriptor and expose AI map generation UI
- load new modules in studio and include ws dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b37892c832a90a8bc62b8df1317