### PR TITLE
Sync hash-driven theming and inverse metrics default

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1909,18 +1909,18 @@
                                 height: 80px;
                                 pointer-events: none;
                         }
-                        .mobile-fs-btn {
-                                display: none;
-                                position: absolute;
-                                right: 10px;
-                                top: 10px;
-                                background: rgba(0, 0, 0, 0.6);
-                                color: #00FF00;
-                                border: 1px solid #00FF00;
-                                border-radius: 6px;
-                                padding: 4px 8px;
-                                z-index: 1001;
-                        }
+                                .mobile-fs-btn {
+                                        display: none;
+                                        position: absolute;
+                                        right: 10px;
+                                        top: 10px;
+                                        background: rgba(0, 0, 0, 0.6);
+                                        color: var(--primary-color);
+                                        border: 1px solid var(--primary-color);
+                                        border-radius: 6px;
+                                        padding: 4px 8px;
+                                        z-index: 1001;
+                                }
                         #btc-mobile-exit {
                                 display: none;
                         }
@@ -1954,8 +1954,8 @@
                                         top: 10px;
                                         right: 10px;
                                         background: rgba(0, 0, 0, 0.6);
-                                        color: #00FF00;
-                                        border: 1px solid #00FF00;
+                                        color: var(--primary-color);
+                                        border: 1px solid var(--primary-color);
                                         border-radius: 6px;
                                         padding: 6px 10px;
                                         z-index: 1001;
@@ -2227,7 +2227,7 @@
                         transform-origin: center;
                     }
                     .q-hero-canvas.glow {
-                        box-shadow: 0 0 24px #00FF00;
+                        box-shadow: 0 0 24px var(--primary-color);
                     }
                     .center-content {
                         text-align: center;
@@ -2281,7 +2281,7 @@
                         background: #111;
                         color: #fff;
                         font-weight: 600;
-                        border: 1px solid #00FF00;
+                        border: 1px solid var(--primary-color);
                         border-radius: 6px;
                         font-size: 1.15em;
                         padding: 0.7em;
@@ -2292,7 +2292,7 @@
                     }
                     .login-btn:hover,
                     .login-btn:focus {
-                        background: #00FF00;
+                        background: var(--primary-color);
                         color: #111;
                     }
                     .buttons {
@@ -2519,7 +2519,7 @@
                 </style>
         </head>
         <body
-                class="text-white min-h-screen flex flex-col overflow-x-hidden overflow-y-auto scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-[\#00FF00]"
+                class="text-white min-h-screen flex flex-col overflow-x-hidden overflow-y-auto scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-[var(--primary-color)]"
         >
                <div class="seg fixed top-2 right-2 z-50" role="group" aria-label="Theme">
                        <button class="btn" id="theme-dark" aria-pressed="true" title="Dark">◐</button>
@@ -3534,7 +3534,7 @@
 							<canvas id="gas-heatmap-canvas"></canvas>
                                                         <div id="gas-heatmap-legend">
                                                                 <div class="legend-item">
-                                                                        <div class="legend-color" style="background: #00ff00"></div>
+                                                                        <div class="legend-color" style="background: var(--primary-color)"></div>
                                                                         <span>Safe</span>
                                                                 </div>
                                                                 <div class="legend-item">
@@ -4389,12 +4389,31 @@
 				bitcrusherNode,
 				gainNode;
                         const themes = {
-                                original: ['#add8e6', '#7ec8e3', '#55a7d5', '#e0f7ff'],
+                                original: ['#00ff00'],
                                 heatmap: ['#00ff00', '#ffff00', '#ff0000'],
                                 lifecycle: ['#003366', '#0077cc', '#00ccff']
                         };
                         let currentTheme = 'heatmap';
-			let siteColors = themes.original;
+                        let siteColors = themes[currentTheme];
+                        let currentHashColor = siteColors[0];
+
+                       function hexToRgba(hex, alpha = 1) {
+                               const r = parseInt(hex.slice(1, 3), 16);
+                               const g = parseInt(hex.slice(3, 5), 16);
+                               const b = parseInt(hex.slice(5, 7), 16);
+                               return `rgba(${r},${g},${b},${alpha})`;
+                       }
+
+                       function updateHighlights(color) {
+                               const root = document.documentElement;
+                               root.style.setProperty('--primary-color', color);
+                               root.style.setProperty('--secondary-color', color);
+                               root.style.setProperty('--focus', color);
+                               root.style.setProperty('--ring', hexToRgba(color, 0.35));
+                               root.style.setProperty('--shadow-color', hexToRgba(color, 0.3));
+                               window.dispatchEvent(new CustomEvent('highlightChange', { detail: color }));
+                       }
+                       updateHighlights(currentHashColor);
 			let currentEthPrice = 0;
                         let isUsingMockLogs = false;
 			let gasHistory = [];
@@ -5720,13 +5739,15 @@ function setupModuleToggles() {
 							latestPrice) *
 						100;
 					const momentum = latestPrice - prices[prices.length - 2][1];
-					const cloudColorHex = getThemeColor(
-						volatility,
-						latestVolume,
-						minVolume,
-						maxVolume
-					);
-					const cloudColor = new THREE.Color(cloudColorHex);
+                                        const cloudColorHex = getThemeColor(
+                                                volatility,
+                                                latestVolume,
+                                                minVolume,
+                                                maxVolume
+                                        );
+                                        const cloudColor = new THREE.Color(cloudColorHex);
+                                        currentHashColor = cloudColorHex;
+                                        updateHighlights(currentHashColor);
 
 					const dotPositions = [];
 					const dotColors = [];
@@ -5950,7 +5971,8 @@ function setupModuleToggles() {
 
                         function setTheme(name) {
                                 currentTheme = name;
-                                siteColors = themes[name] || themes.original;
+                                siteColors = themes[currentTheme] || ['#00ff00'];
+                                updateHighlights(currentHashColor);
                                 colorLegend = [];
                                 dotClouds.forEach((c) => scene.remove(c));
                                 dotClouds = [];
@@ -6006,7 +6028,8 @@ function setupModuleToggles() {
 				});
 
                                 const getColor = (type) => {
-                                        if (type === 'safe') return '#00ff00';
+                                        if (type === 'safe')
+                                                return STYLE.getPropertyValue('--primary-color').trim() || '#00ff00';
                                         if (type === 'propose') return '#ffff00';
                                         return '#ff0000';
                                 };
@@ -6216,6 +6239,10 @@ function setupModuleToggles() {
                                 const ctx = DOM.tokenPerformanceChart.getContext('2d');
                                 const labels = tokens.map((token) => token.symbol);
                                 const data = tokens.map((token) => parseFloat(token.price_change_percentage_24h) || 0);
+                                const primary =
+                                        getComputedStyle(document.documentElement)
+                                                .getPropertyValue('--primary-color')
+                                                .trim() || '#00FF00';
                                 new Chart(ctx, {
                                         type: 'bar',
                                         data: {
@@ -6225,10 +6252,10 @@ function setupModuleToggles() {
                                                                 label: '24h Price Change (%)',
                                                                 data: data,
                                                                 backgroundColor: data.map((value) =>
-                                                                        value >= 0 ? '#00FF00' : '#FF0000'
+                                                                        value >= 0 ? primary : '#FF0000'
                                                                 ),
                                                                 borderColor: data.map((value) =>
-                                                                        value >= 0 ? '#00FF00' : '#FF0000'
+                                                                        value >= 0 ? primary : '#FF0000'
                                                                 ),
                                                                 borderWidth: 1
                                                         }
@@ -7962,13 +7989,13 @@ function setupModuleToggles() {
 				});
 		</script>
 		<script>
-			let inverseChart;
+                        let inverseChart;
 
-			async function loadInverseChart(topCount = 10) {
-				const response = await fetch(
-					'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd'
-				);
-				const tokens = await response.json();
+                        async function loadInverseChart(topCount = 5) {
+                                const response = await fetch(
+                                        `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&per_page=50`
+                                );
+                                const tokens = await response.json();
 
 				const marketTrend = tokens.reduce(
 					(sum, t) => sum + t.price_change_percentage_24h,
@@ -7986,7 +8013,8 @@ function setupModuleToggles() {
 
                                 const labels = filteredTokens.map((t) => t.symbol.toUpperCase());
                                 const data = filteredTokens.map((t) => t.price_change_percentage_24h);
-                                const green = '#00FF00';
+                                const rootStyle = getComputedStyle(document.documentElement);
+                                const green = rootStyle.getPropertyValue('--primary-color').trim() || '#00FF00';
                                 const red = '#e74c3c';
                                 const bgColor = data.map((change) => (change >= 0 ? green : red));
 
@@ -8041,7 +8069,8 @@ function setupModuleToggles() {
                                 if (unlocked) {
                                         document.body.classList.remove('locked');
                                         initIntroVideo();
-                                        loadInverseChart(10);
+                                        const topDefault = parseInt(document.getElementById('topCount').value);
+                                        loadInverseChart(topDefault);
                                 } else {
                                         document.body.classList.add('locked');
                                 }
@@ -8097,7 +8126,7 @@ function setupModuleToggles() {
                                                overlay.style.display = 'none';
                                                document.body.classList.remove('locked');
                                                if (typeof initIntroVideo === 'function') initIntroVideo();
-                                               loadInverseChart(10);
+                                               loadInverseChart(5);
                                        } else {
                                                error.textContent = 'Incorrect password or missing agreement';
                                                error.classList.remove('hidden');

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -20,18 +20,18 @@
       /* ---------- Design System ---------- */
       *, *::before, *::after { box-sizing: border-box; }
       :root{
-        --bg:#0e1013; --fg:#f7f8fb; --muted:#cfd3d8; --accent:#00FF7F; --accent-2:#00FF00;
-        --border:rgba(0,255,127,.28); --card:#0b0d10; --soft:rgba(0,255,127,.10);
-        --focus:#00FF7F; --danger:#ff6161; --ring: rgba(0,255,127,.35);
+        --bg:#0e1013; --fg:#f7f8fb; --muted:#cfd3d8; --accent:#00FF00; --accent-2:#00FF00;
+        --border:rgba(0,255,0,.28); --card:#0b0d10; --soft:rgba(0,255,0,.10);
+        --focus:#00FF00; --danger:#ff6161; --ring: rgba(0,255,0,.35);
         --safe-top: env(safe-area-inset-top); --safe-bottom: env(safe-area-inset-bottom);
         --panel-bg: rgba(13,15,18,.55); --panel-brd: rgba(255,255,255,.08);
         --chip-bg: rgba(255,255,255,.06);
       }
       [data-theme="light"]{
         --bg:#f2f2f7; --fg:#0b0e11; --muted:#6b7280;
-        --accent:#0A84FF; --accent-2:#34C759;
-        --border:rgba(10,132,255,.18); --card:#ffffff; --soft:rgba(10,132,255,.06);
-        --focus:#0A84FF; --danger:#ff3b30; --ring: rgba(10,132,255,.24);
+        --accent:#00FF00; --accent-2:#00FF00;
+        --border:rgba(0,255,0,.18); --card:#ffffff; --soft:rgba(0,255,0,.06);
+        --focus:#00FF00; --danger:#ff3b30; --ring: rgba(0,255,0,.24);
         --panel-bg: rgba(255,255,255,.92); --panel-brd: rgba(0,0,0,.06);
         --chip-bg: rgba(0,0,0,.04);
       }
@@ -107,9 +107,9 @@
       [data-theme="light"] .ctrl input, [data-theme="light"] .ctrl select{ background:#fff; color:#111; border-color:#cbd5e1; }
       .ctrl input:focus, .ctrl select:focus{ border-color:var(--focus); box-shadow:0 0 0 3px var(--ring); }
       .ctrl input[type="range"]{ padding:0; -webkit-appearance:none; appearance:none; background:transparent; }
-      .ctrl input[type="range"]::-webkit-slider-runnable-track{ height:4px; background:rgba(10,132,255,.3); border-radius:2px; }
+      .ctrl input[type="range"]::-webkit-slider-runnable-track{ height:4px; background:var(--ring); border-radius:2px; }
       .ctrl input[type="range"]::-webkit-slider-thumb{ -webkit-appearance:none; width:18px; height:18px; border-radius:50%; background:var(--accent); cursor:pointer; margin-top:-7px; }
-      .ctrl input[type="range"]::-moz-range-track{ height:4px; background:rgba(10,132,255,.3); border-radius:2px; }
+      .ctrl input[type="range"]::-moz-range-track{ height:4px; background:var(--ring); border-radius:2px; }
       .ctrl input[type="range"]::-moz-range-thumb{ width:18px; height:18px; border-radius:50%; background:var(--accent); cursor:pointer; }
 
       /* Dropzone */
@@ -348,12 +348,36 @@
       }
 
       const themes = {
-        original: ['#00ff7f','#44ffaa','#bbffdd'],
+        original: ['#00ff00'],
         heatmap(v){ const t = Math.min(1, Math.max(0, (v-0)/(10-0))); const r=Math.round(255*t), g=Math.round(255*(1-t)); return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}00`; },
         lifecycle(vol, minV, maxV){ const t=(vol-minV)/(maxV-minV+1e-6); const c=Math.round(255*(0.3+0.7*t)); return `#00${c.toString(16).padStart(2,'0')}ff`; }
       };
       const getThemeColor = (volatility, volume, minV, maxV) => {
         const mode = $('theme').value; if (mode==='heatmap') return themes.heatmap(volatility); if (mode==='lifecycle') return themes.lifecycle(volume, minV, maxV); return themes.original[0]; };
+
+      let currentHashColor = themes.original[0];
+      function hexToRgba(hex, alpha=1){
+        const r=parseInt(hex.slice(1,3),16);
+        const g=parseInt(hex.slice(3,5),16);
+        const b=parseInt(hex.slice(5,7),16);
+        return `rgba(${r},${g},${b},${alpha})`;
+      }
+      function updateHighlights(color){
+        const root=document.documentElement;
+        root.style.setProperty('--accent', color);
+        root.style.setProperty('--accent-2', color);
+        root.style.setProperty('--focus', color);
+        root.style.setProperty('--ring', hexToRgba(color,0.35));
+        root.style.setProperty('--border', hexToRgba(color,0.28));
+        root.style.setProperty('--soft', hexToRgba(color,0.1));
+        if(tube){
+          const tCol=new THREE.Color(color);
+          tube.material.color.set(tCol);
+          tube.material.emissive.set(tCol.clone().multiplyScalar(0.2));
+        }
+        window.dispatchEvent(new CustomEvent('highlightChange', { detail: color }));
+      }
+      updateHighlights(currentHashColor);
 
       async function fetchWithRetry(url, opts = {}, retries = 2, delay = 600) {
         for (let i = 0; i <= retries; i++) { try { const r = await fetch(url, opts); if (!r.ok) throw new Error(`${r.status}`); return await r.json(); } catch (e){ if (i === retries) throw e; await new Promise(res=>setTimeout(res, delay*Math.pow(2,i))); } }
@@ -480,7 +504,10 @@
         const minVolume = Math.min(...volumes.map(v=>v[1])), maxVolume = Math.max(...volumes.map(v=>v[1]));
         const latestPrice = prices[prices.length-1][1]; const latestVolume = volumes[volumes.length-1][1];
         const recent = prices.slice(-10).map(p=>p[1]); const volatility = ((Math.max(...recent)-Math.min(...recent))/latestPrice)*100;
-        const cloudColorHex = getThemeColor(volatility, latestVolume, minVolume, maxVolume); const cloudColor = new THREE.Color(cloudColorHex);
+        const cloudColorHex = getThemeColor(volatility, latestVolume, minVolume, maxVolume);
+        const cloudColor = new THREE.Color(cloudColorHex);
+        currentHashColor = cloudColorHex;
+        updateHighlights(currentHashColor);
         const pointsPerCloud = parseInt($('density').value,10);
         const positions=[]; const colors=[]; const jitter=0.6; const centers=[];
         for(let i=0;i<prices.length;i++){
@@ -516,11 +543,12 @@
         }
         scene.add(cloud); dotClouds.push(cloud);
         dotClouds.slice(0,-1).forEach(c=>c.material.opacity = Math.max(.12, c.material.opacity - .06));
+        buildTubeFrom(centers);
       }
 
       function layoutFromHash(hash, mapping){
         const vals = Array.from(hash).map(ch=>parseInt(ch,16)); const N = 256; const positions=[]; const colors=[]; const pathPts=[];
-        const base = new THREE.Color(themes.original[dotClouds.length % themes.original.length]);
+        const base = new THREE.Color(currentHashColor);
         for(let i=0;i<N;i++){
           const v = vals[i % vals.length] / 15; let x,y,z;
           if(mapping==='spiral'){ const a=i*.28, r=2+v*4; x=Math.cos(a)*r; y=Math.sin(a)*r; z=(i/N)*16-8; }
@@ -549,6 +577,8 @@
         }
         scene.add(cloud); dotClouds.push(cloud);
         dotClouds.slice(0,-1).forEach(c=>c.material.opacity = Math.max(.12, c.material.opacity - .06));
+        buildTubeFrom(pathPts);
+        updateHighlights(currentHashColor);
       }
 
       async function updateHashCloud(){
@@ -852,6 +882,9 @@
           dotClouds.forEach(c => c.material.size = parseFloat($('pointSize').value));
         });
         $('theme').addEventListener('change', async () => {
+          const base = getThemeColor(0,0,0,1);
+          currentHashColor = base;
+          updateHighlights(base);
           if ($('mapping').value === 'original') {
             clearClouds();
             await drawOriginalFromMarket();
@@ -1191,7 +1224,8 @@
     const bb=new THREE.Box3().setFromPoints(curvePts); const diag=bb.getSize(new THREE.Vector3()).length();
     const radius = Math.max(0.12, Math.min(0.36, diag*0.012));
     const geo=new THREE.TubeGeometry(curve, Math.min(2400, curvePts.length*6), radius, 16, false);
-    const mat=new THREE.MeshStandardMaterial({ color:0x00ff98, emissive:0x00331c, transparent:true, opacity:0.28, roughness:0.35, metalness:0.05 });
+    const tCol=new THREE.Color(currentHashColor);
+    const mat=new THREE.MeshStandardMaterial({ color:tCol, emissive:tCol.clone().multiplyScalar(0.2), transparent:true, opacity:0.28, roughness:0.35, metalness:0.05 });
     tube=new THREE.Mesh(geo,mat); tube.name='HashTube'; tube.visible=pathVisible;
     scene.add(tube);
     return true;


### PR DESCRIPTION
## Summary
- Broadcast highlight updates so index and studio accents track live BTC hash color
- Replace hard-coded greens with CSS variables and brand green defaults in both pages
- Fix inverse metrics chart to load top five tokens by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b051979114832a94c299f0406453fa