### PR TITLE
feat: update btc hash theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -71,25 +71,25 @@
 		<script src="https://www.youtube.com/iframe_api"></script>
                 <style>
                         :root {
-                                --quantumi-green: #00FF00;
-                                --quantumi-black: #010101;
-                                --quantumi-white: #F8F8F8;
-                                --quantumi-gray: #1A1A1A;
-                                --quantumi-accent: #00FF00;
-                                --quantumi-radius: 18px;
-                                --quantumi-blur: 18px;
+                               --quantumi-btc: #F7931A;
+                               --quantumi-black: #010101;
+                               --quantumi-white: #F8F8F8;
+                               --quantumi-gray: #1A1A1A;
+                               --quantumi-accent: #F7931A;
+                               --quantumi-radius: 18px;
+                               --quantumi-blur: 18px;
 
-                                --bg-color: var(--quantumi-black);
-                                --text-color: var(--quantumi-white);
-                                --primary-color: var(--quantumi-green);
-                                --secondary-color: var(--quantumi-green);
-                                --shadow-color: rgba(0, 255, 0, 0.3);
-                                --panel-bg: rgba(12,15,18,.6);
-                                --panel-brd: rgba(255,255,255,.08);
-                                --card: rgba(12,15,18,.6);
-                                --focus: var(--primary-color);
-                                --ring: rgba(0,255,0,.35);
-                        }
+                               --bg-color: var(--quantumi-black);
+                               --text-color: var(--quantumi-white);
+                               --primary-color: var(--quantumi-btc);
+                               --secondary-color: var(--quantumi-btc);
+                               --shadow-color: rgba(247, 147, 26, 0.3);
+                               --panel-bg: rgba(12,15,18,.6);
+                               --panel-brd: rgba(255,255,255,.08);
+                               --card: rgba(12,15,18,.6);
+                               --focus: var(--primary-color);
+                               --ring: rgba(247,147,26,.35);
+                       }
                        body {
                                font-family: 'Inter', 'Segoe UI', sans-serif;
                                background: var(--bg-color);
@@ -107,7 +107,7 @@
                                --panel-bg: rgba(255,255,255,.7);
                                --panel-brd: rgba(0,0,0,.1);
                                --card: rgba(255,255,255,.7);
-                               --shadow-color: rgba(0,255,0,.2);
+                               --shadow-color: rgba(247,147,26,.2);
                        }
                        body.locked > :not(#access-overlay) {
                                display: none !important;
@@ -1140,8 +1140,8 @@
                                 padding: 0.65em 1.5em;
                                 font-size: clamp(13px, 2vw, 19px);
                                 background: transparent;
-                                color: #fff;
-                                border: 1.5px solid rgba(0, 255, 0, 0.3);
+                               color: #fff;
+                               border: 1.5px solid rgba(247, 147, 26, 0.3);
                                 border-radius: 8px;
                                 cursor: pointer;
                                 font-family: inherit;
@@ -1152,17 +1152,17 @@
                         .toggle-desc-btn:hover:not(.active),
                         #hash-log-toggle:hover:not(.active),
                         #legend-toggle:hover:not(.active) {
-                                background: rgba(0, 255, 0, 0.15);
+                               background: rgba(247, 147, 26, 0.15);
                         }
                         .toggle-module-btn.active,
                         .toggle-desc-btn.active,
                         #hash-log-toggle.active,
                         #legend-toggle.active {
-                                background: rgba(0, 255, 0, 0.4);
-                                color: #000;
-                                box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
-                                border-color: rgba(0, 255, 0, 0.8);
-                        }
+                               background: rgba(247, 147, 26, 0.4);
+                               color: #000;
+                               box-shadow: 0 0 8px rgba(247, 147, 26, 0.8);
+                               border-color: rgba(247, 147, 26, 0.8);
+                       }
 			.module-content.hidden {
 				display: none;
 			}
@@ -1200,7 +1200,7 @@
                                 border-radius: 4px;
                         }
                         #token-search::placeholder {
-                                color: rgba(0,255,0,0.6);
+                               color: rgba(247,147,26,0.6);
                         }
                         #gas-heatmap-list,
                         #balances-list,
@@ -2316,13 +2316,13 @@
                         outline: none;
                     }
                     .btn.selected {
-                        background: rgba(0,255,0,0.3);
+                        background: rgba(247,147,26,0.3);
                         color: #fff;
-                        border-color: rgba(0,255,0,0.4);
+                        border-color: rgba(247,147,26,0.4);
                     }
                     .btn:hover:not(.selected),
                     .btn:focus:not(.selected) {
-                        background: rgba(0,255,0,0.2);
+                        background: rgba(247,147,26,0.2);
                         color: #fff;
                         transform: scale(1.04);
                     }
@@ -3283,7 +3283,7 @@
 
                           // Brand colors
                           const STYLE = getComputedStyle(document.documentElement);
-                          const BRAND_COLOR = STYLE.getPropertyValue('--primary-color').trim() || '#00FF00';
+                          const BRAND_COLOR = STYLE.getPropertyValue('--primary-color').trim() || '#F7931A';
                           const TEXT_COLOR = STYLE.getPropertyValue('--text-color').trim() || '#F8F8F8';
                           const PANEL_BG = STYLE.getPropertyValue('--panel-bg').trim() || '#0c0f12';
                           const PANEL_BRD = STYLE.getPropertyValue('--panel-brd').trim() || '#1A1A1A';
@@ -4389,8 +4389,8 @@
 				bitcrusherNode,
 				gainNode;
                         const themes = {
-                                original: ['#00ff00'],
-                                heatmap: ['#00ff00', '#ffff00', '#ff0000'],
+                                original: ['#f7931a'],
+                                heatmap: ['#f7931a', '#ffff00', '#ff0000'],
                                 lifecycle: ['#003366', '#0077cc', '#00ccff']
                         };
                         let currentTheme = 'heatmap';
@@ -5220,7 +5220,7 @@ function setupModuleToggles() {
 
                                 const initWidget = () => {
                                         const style = getComputedStyle(document.documentElement);
-                                        const upColor = style.getPropertyValue('--primary-color').trim() || '#00FF00';
+                                        const upColor = style.getPropertyValue('--primary-color').trim() || '#F7931A';
                                         const downColor = '#ff0000';
                                         try {
                                                 const widget = new TradingView.widget({
@@ -5971,7 +5971,7 @@ function setupModuleToggles() {
 
                         function setTheme(name) {
                                 currentTheme = name;
-                                siteColors = themes[currentTheme] || ['#00ff00'];
+                                siteColors = themes[currentTheme] || ['#f7931a'];
                                 updateHighlights(currentHashColor);
                                 colorLegend = [];
                                 dotClouds.forEach((c) => scene.remove(c));
@@ -6029,7 +6029,7 @@ function setupModuleToggles() {
 
                                 const getColor = (type) => {
                                         if (type === 'safe')
-                                                return STYLE.getPropertyValue('--primary-color').trim() || '#00ff00';
+                                                return STYLE.getPropertyValue('--primary-color').trim() || '#f7931a';
                                         if (type === 'propose') return '#ffff00';
                                         return '#ff0000';
                                 };
@@ -6242,7 +6242,7 @@ function setupModuleToggles() {
                                 const primary =
                                         getComputedStyle(document.documentElement)
                                                 .getPropertyValue('--primary-color')
-                                                .trim() || '#00FF00';
+                                                .trim() || '#F7931A';
                                 new Chart(ctx, {
                                         type: 'bar',
                                         data: {
@@ -8020,7 +8020,7 @@ function setupModuleToggles() {
                                 const labels = filteredTokens.map((t) => t.symbol.toUpperCase());
                                 const data = filteredTokens.map((t) => t.price_change_percentage_24h);
                                 const rootStyle = getComputedStyle(document.documentElement);
-                                const green = rootStyle.getPropertyValue('--primary-color').trim() || '#00FF00';
+                                const green = rootStyle.getPropertyValue('--primary-color').trim() || '#F7931A';
                                 const red = '#e74c3c';
                                 const bgColor = data.map((change) => (change >= 0 ? green : red));
 

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -20,18 +20,18 @@
       /* ---------- Design System ---------- */
       *, *::before, *::after { box-sizing: border-box; }
       :root{
-        --bg:#0e1013; --fg:#f7f8fb; --muted:#cfd3d8; --accent:#00FF00; --accent-2:#00FF00;
-        --border:rgba(0,255,0,.28); --card:#0b0d10; --soft:rgba(0,255,0,.10);
-        --focus:#00FF00; --danger:#ff6161; --ring: rgba(0,255,0,.35);
+        --bg:#0e1013; --fg:#f7f8fb; --muted:#cfd3d8; --accent:#F7931A; --accent-2:#F7931A;
+        --border:rgba(247,147,26,.28); --card:#0b0d10; --soft:rgba(247,147,26,.10);
+        --focus:#F7931A; --danger:#ff6161; --ring: rgba(247,147,26,.35);
         --safe-top: env(safe-area-inset-top); --safe-bottom: env(safe-area-inset-bottom);
         --panel-bg: rgba(13,15,18,.55); --panel-brd: rgba(255,255,255,.08);
         --chip-bg: rgba(255,255,255,.06);
       }
       [data-theme="light"]{
         --bg:#f2f2f7; --fg:#0b0e11; --muted:#6b7280;
-        --accent:#00FF00; --accent-2:#00FF00;
-        --border:rgba(0,255,0,.18); --card:#ffffff; --soft:rgba(0,255,0,.06);
-        --focus:#00FF00; --danger:#ff3b30; --ring: rgba(0,255,0,.24);
+        --accent:#F7931A; --accent-2:#F7931A;
+        --border:rgba(247,147,26,.18); --card:#ffffff; --soft:rgba(247,147,26,.06);
+        --focus:#F7931A; --danger:#ff3b30; --ring: rgba(247,147,26,.24);
         --panel-bg: rgba(255,255,255,.92); --panel-brd: rgba(0,0,0,.06);
         --chip-bg: rgba(0,0,0,.04);
       }
@@ -348,7 +348,7 @@
       }
 
       const themes = {
-        original: ['#00ff00'],
+        original: ['#f7931a'],
         heatmap(v){ const t = Math.min(1, Math.max(0, (v-0)/(10-0))); const r=Math.round(255*t), g=Math.round(255*(1-t)); return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}00`; },
         lifecycle(vol, minV, maxV){ const t=(vol-minV)/(maxV-minV+1e-6); const c=Math.round(255*(0.3+0.7*t)); return `#00${c.toString(16).padStart(2,'0')}ff`; }
       };
@@ -851,12 +851,11 @@
         // Stage init
         init3D();
         animate();
-        await drawOriginalFromMarket();
+        await updateHashCloud();
         $('m-status').textContent = 'Status — Ready';
         const { price: initialPrice } = await fetchBTCPrice();
         addHashLog(generateHashFromPrice(initialPrice), new Date().toLocaleTimeString());
         setInterval(updateHashCloud, 60_000);
-        updateHashCloud();
 
         // Mapping
         $('mapping').addEventListener('change', async (e) => {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -9,14 +9,14 @@ header, footer {
   background: rgba(31, 41, 55, 0.5);
   backdrop-filter: blur(10px);
   padding: 1rem;
-  border-bottom: 1px solid rgba(0, 255, 0, 0.1); /* Ice King green accent */
+  border-bottom: 1px solid rgba(247, 147, 26, 0.1); /* BTC accent */
 }
 
 section {
   background: rgba(31, 41, 55, 0.5);
   backdrop-filter: blur(10px);
   padding: 1rem;
-  border: 1px solid rgba(0, 255, 0, 0.1);
+  border: 1px solid rgba(247, 147, 26, 0.1);
   border-radius: 8px;
   box-sizing: border-box;
   overflow: hidden;
@@ -64,15 +64,15 @@ canvas {
 
 /* Visual enhancements for Ice King theme */
 .gradient-bg {
-  background: linear-gradient(45deg, rgba(0, 255, 0, 0.1), rgba(0, 0, 0, 0.5));
+  background: linear-gradient(45deg, rgba(247, 147, 26, 0.1), rgba(0, 0, 0, 0.5));
 }
 
 .hover-glow:hover {
-  box-shadow: 0 0 15px rgba(0, 255, 0, 0.5); /* Green glow on hover */
+  box-shadow: 0 0 15px rgba(247, 147, 26, 0.5); /* Accent glow on hover */
 }
 
 .glow-green {
-  box-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
+  box-shadow: 0 0 10px rgba(247, 147, 26, 0.3);
 }
 
 .glow-red {
@@ -81,7 +81,7 @@ canvas {
 
 .glow-blue,
 .glow-purple {
-  box-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
+  box-shadow: 0 0 10px rgba(247, 147, 26, 0.3);
 }
 
 .fade-in {
@@ -107,7 +107,7 @@ button {
 button:hover,
 button:focus,
 button:active {
-  background: #00FF00;
+  background: var(--primary-color);
   color: #000;
 }
 
@@ -117,7 +117,7 @@ button:active {
   align-items: center;
   justify-content: center;
   background: #25272a;
-  color: #e3e3e3cc;
+  color: var(--primary-color);
   border: 1.5px solid transparent;
   border-radius: 8px;
   padding: 0.5rem;
@@ -128,7 +128,7 @@ button:active {
 .module-arrow:focus {
   background: #393a41;
   color: #fff;
-  border-color: #a5b5ff44;
+  border-color: var(--primary-color);
 }
 
 .loader {


### PR DESCRIPTION
## Summary
- replace green accent with bitcoin orange across index and styles
- sync module arrow styling with dynamic theme color
- load BTC hash cloud on Studio start to fix missing display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b168e7b440832aa20251a2e621a2e4