### PR TITLE
Refine cluster gravity and exploration features

### DIFF
--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -196,7 +196,7 @@
             <div class="chip" id="m-diff">Difficulty —</div>
             <div class="chip" id="m-mode">Mode — Original</div>
             <div class="chip" id="m-axes">Axes — On</div>
-            <div class="chip" id="m-cloud">Cloud — On</div>
+            <div class="chip" id="m-cloud">Cluster Metrics — Off</div>
             <div class="chip" id="m-clusters">Clusters — 0</div>
             <div class="chip" id="m-status">Status — Init…</div>
           </div>
@@ -348,8 +348,8 @@
       const $ = (id) => document.getElementById(id);
       const nfUSD = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
       const canvas = $('btc-hash-canvas');
-      let renderer, scene, camera, controls, axes; let dotClouds = []; let hashLogEntries = []; let customGeometry = null; let cloudVisible = true;
-      let clusterDev = false; let clusterInfoEl = null;
+      let renderer, scene, camera, controls, axes; let dotClouds = []; let hashLogEntries = []; let customGeometry = null;
+      let clusterDev = false; let clusterInfoEl = null; let clusterMetricsVisible = false;
       const DPR_CAP = Math.min((window.devicePixelRatio||1), 1.8);
       let __targetDPR = Math.min(DPR_CAP, 1.4); // start moderate on mobile
 
@@ -553,6 +553,7 @@
         clusterMeshes.forEach(m=>scene.remove(m)); clusterMeshes=[];
         if(clusterInfoEl) clusterInfoEl.innerHTML='';
         lastClusters = detectClusters(points);
+        // spheres act as gravity wells instead of boundaries
         lastClusters.forEach((c,idx)=>{
           const geo=new THREE.SphereGeometry(c.radius,16,16);
           const mat=new THREE.MeshBasicMaterial({color:currentHashColor,wireframe:true,transparent:true,opacity:0.25});
@@ -565,6 +566,22 @@
           }
         });
         $('m-clusters').textContent = `Clusters — ${lastClusters.length}`;
+      }
+
+      function applyClusterGravity(){
+        if(!camera||!controls) return;
+        const pos=camera.position;
+        const pull=new THREE.Vector3();
+        lastClusters.forEach(c=>{
+          const dir=c.center.clone().sub(pos);
+          const dist=dir.length();
+          if(dist<c.radius){
+            const strength=(1 - dist / c.radius)*0.02;
+            pull.add(dir.normalize().multiplyScalar(strength));
+          }
+        });
+        camera.position.add(pull);
+        controls.target.add(pull);
       }
 
       function clearClouds(){
@@ -620,7 +637,7 @@
           const mat = new THREE.PointsMaterial({ size: parseFloat($('pointSize').value), vertexColors:true, transparent:true, opacity:1 });
           cloud = new THREE.Points(geo,mat);
         }
-        scene.add(cloud); cloud.visible = cloudVisible; dotClouds.push(cloud);
+        scene.add(cloud); dotClouds.push(cloud);
         dotClouds.slice(0,-1).forEach(c=>c.material.opacity = Math.max(.12, c.material.opacity - .06));
       }
 
@@ -664,7 +681,7 @@
           const mat=new THREE.PointsMaterial({ size: parseFloat($('pointSize').value), vertexColors:true, transparent:true, opacity:1 });
           cloud=new THREE.Points(geo,mat);
         }
-        scene.add(cloud); cloud.visible = cloudVisible; dotClouds.push(cloud);
+        scene.add(cloud); dotClouds.push(cloud);
         dotClouds.slice(0,-1).forEach(c=>c.material.opacity = Math.max(.12, c.material.opacity - .06));
       }
 
@@ -878,6 +895,11 @@
         document.dispatchEvent(new CustomEvent('quantumi:tick',{ detail:{ dt } }));
         controls && controls.update();
         handleGamepadInput();
+        if(!controls.enabled){
+          scene.rotation.y += 0.002;
+          controls.autoRotate = true;
+        }
+        applyClusterGravity();
         if (camera) {
           const cp = $('camera-pos');
           if (cp) cp.textContent = `Pos: ${camera.position.x.toFixed(2)},${camera.position.y.toFixed(2)},${camera.position.z.toFixed(2)}`;
@@ -1076,9 +1098,9 @@
           vibrate(8,gamepadAPI.controller);
         }); }
         $('toggle-cloud').addEventListener('click', () => {
-          cloudVisible = !cloudVisible;
-          dotClouds.forEach(c=>c.visible = cloudVisible);
-          $('m-cloud').textContent = `Cloud — ${cloudVisible ? 'On' : 'Off'}`;
+          clusterMetricsVisible = !clusterMetricsVisible;
+          if(clusterInfoEl) clusterInfoEl.classList.toggle('on', clusterMetricsVisible);
+          $('m-cloud').textContent = `Cluster Metrics — ${clusterMetricsVisible ? 'On' : 'Off'}`;
           vibrate(8, gamepadAPI.controller);
         });
 


### PR DESCRIPTION
## Summary
- Rework cluster spheres into gravity wells and keep BTC hash visible while toggling metrics
- Display cluster metrics via the cloud control and allow hash rotation during explore mode

## Testing
- `/usr/bin/npm test` *(fails: No such file or directory)*
- `/usr/bin/apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ea896dc832a87ca739c6d6ddcf3