### PR TITLE
Enable cluster traversal in BTC hash studio

### DIFF
--- a/frontend/fpv-explore.js
+++ b/frontend/fpv-explore.js
@@ -240,9 +240,9 @@ const THREE = window.THREE;
       } else {
         thrustHold=0;
       }
-      if(walkCluster && Q.camera.position.distanceTo(walkCluster.center) > walkCluster.radius){
-        t = walkCluster.t || t;
-        walking=false; walkCluster=null; walkClusterIdx=-1;
+      const cls=window.QUANTUMI?.clusters||[];
+      for(let i=0;i<cls.length;i++){
+        if(Q.camera.position.distanceTo(cls[i].center)<cls[i].radius){ walkCluster=cls[i]; walkClusterIdx=i; break; }
       }
       return;
     }
@@ -314,10 +314,11 @@ const THREE = window.THREE;
     if(!cls.length) return;
     idx = (idx + cls.length) % cls.length;
     const c = cls[idx];
-    jumpTargetT = c.t || 0;
-    walking=false;
-    walkCluster=null;
-    walkClusterIdx=-1;
+    if(Q && Q.camera){
+      Q.camera.position.set(c.center.x, c.center.y + c.radius + 2, c.center.z);
+    }
+    walkCluster = c;
+    walkClusterIdx = idx;
   }
 
   // ---------- toggle ----------
@@ -334,6 +335,8 @@ const THREE = window.THREE;
       // start on crest
       const {N,B} = frameAt(t=0);
       u = crestAngle(N,B); yaw=0; pitch=0; sYaw=0; sPitch=0; sVel.set(0,0,0);
+      walking=true;
+      if(!isTouch) window.walkMode?.startWalkMode(Q.camera, Q.renderer);
       mountHUD();
     } else {
       Q.controls && (Q.controls.enabled=true, Q.controls.update?.());

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -150,6 +150,9 @@
         .fpv-joy .knob{position:absolute;left:37px;top:37px;width:58px;height:58px;border-radius:999px;background:rgba(255,255,255,.22)}
         .fpv-run{position:absolute;bottom:42px;right:22px}
         .fpv-cross{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:12px;height:12px;border:2px solid rgba(255,255,255,.9);border-radius:50%}
+        /* Fade overlay for respawn */
+        .fade-overlay{position:fixed;inset:0;background:#000;opacity:0;pointer-events:none;transition:opacity .8s;z-index:9999}
+        .fade-overlay.on{opacity:1}
       </style>
 
     <!-- three.js r128 (kept for FBXLoader compatibility) -->
@@ -161,6 +164,7 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/libs/inflate.min.js"></script>
   </head>
   <body>
+    <div id="fall-fade" class="fade-overlay"></div>
     <header>
       <div class="brand">
         <div class="logo">QUANTUMI</div>
@@ -573,11 +577,16 @@
         const pos=camera.position;
         const pull=new THREE.Vector3();
         lastClusters.forEach(c=>{
-          const dir=c.center.clone().sub(pos);
-          const dist=dir.length();
+          const toCenter=c.center.clone().sub(pos);
+          const dist=toCenter.length();
           if(dist<c.radius){
-            const strength=(1 - dist / c.radius)*0.02;
-            pull.add(dir.normalize().multiplyScalar(strength));
+            // push outward when inside a cluster sphere
+            const pushStrength=(1 - dist / c.radius)*0.05;
+            pull.add(toCenter.negate().normalize().multiplyScalar(pushStrength));
+          }else{
+            // gentle attraction when nearby to help reach next cluster
+            const attractStrength=Math.max(0,(1 - dist/(c.radius*3)))*0.02;
+            pull.add(toCenter.normalize().multiplyScalar(attractStrength));
           }
         });
         camera.position.add(pull);

--- a/frontend/walkmode.js
+++ b/frontend/walkmode.js
@@ -8,6 +8,9 @@ let moveLeft = false;
 let moveRight = false;
 let canJump = false;
 let isRunning = false;
+let clusters = [];
+let fadeEl = null;
+let respawning = false;
 const speed = 50;
 
 function onKeyDown(event) {
@@ -67,10 +70,25 @@ function onKeyUp(event) {
 }
 
 function startWalkMode(camera, renderer) {
+  clusters = (window.QUANTUMI?.clusters || []).slice();
+  fadeEl = document.getElementById('fall-fade');
   controls = new THREE.PointerLockControls(camera, renderer.domElement);
   renderer.domElement.addEventListener('click', () => controls.lock());
   document.addEventListener('keydown', onKeyDown);
   document.addEventListener('keyup', onKeyUp);
+  if (clusters.length) {
+    const c = clusters[0];
+    camera.position.set(c.center.x, c.center.y + c.radius + 2, c.center.z);
+  }
+}
+
+function groundHeight(pos){
+  let nearest=null, dmin=Infinity;
+  for(const c of clusters){
+    const d = pos.distanceTo(c.center);
+    if(d<dmin){ dmin=d; nearest=c; }
+  }
+  return nearest ? nearest.center.y + nearest.radius : 1;
 }
 
 function update(delta) {
@@ -91,10 +109,27 @@ function update(delta) {
   controls.moveForward(-velocity.z * delta);
 
   camera.position.y += velocity.y * delta;
-  if (camera.position.y < 1) {
+  const g = groundHeight(camera.position);
+  if (camera.position.y < g) {
     velocity.y = 0;
-    camera.position.y = 1;
+    camera.position.y = g;
     canJump = true;
+  }
+  if (camera.position.y < g - 30 && !respawning) {
+    respawning = true;
+    fadeEl && fadeEl.classList.add('on');
+    setTimeout(() => {
+      const first = clusters[0];
+      if (first) {
+        camera.position.set(first.center.x, first.center.y + first.radius + 2, first.center.z);
+      } else {
+        camera.position.set(0, 1, 0);
+      }
+      velocity.set(0, 0, 0);
+      canJump = true;
+      fadeEl && setTimeout(() => fadeEl.classList.remove('on'), 200);
+      respawning = false;
+    }, 800);
   }
 }
 


### PR DESCRIPTION
## Summary
- allow camera to move between BTC hash clusters with gentle gravity
- add fade overlay and respawn logic to restart on first cluster when falling
- update first-person explore mode to start on-foot and support jumping between clusters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b254819ea0832abd5886495a312b40