### PR TITLE
feat: lock explore camera to hash path

### DIFF
--- a/frontend/fpv-explore.js
+++ b/frontend/fpv-explore.js
@@ -300,11 +300,9 @@ const THREE = window.THREE;
     for(let i=0;i<cls.length;i++){
       const c=cls[i];
       if(cam.position.distanceTo(c.center)<c.radius){
-        walking=true;
         walkCluster=c;
         walkClusterIdx=i;
-        if(!isTouch) window.walkMode?.startWalkMode(Q.camera, Q.renderer);
-        return;
+        // remain locked to the hash; walking mode must be triggered manually
       }
     }
   }
@@ -332,11 +330,10 @@ const THREE = window.THREE;
       if(!buildCurve()){ console.warn('FPV: no path'); isFPV=false; return; }
       await enterFS(stage);
       if(!isTouch) enablePointerLook(stage);
-      // start on crest
+      // start on crest of the path
       const {N,B} = frameAt(t=0);
       u = crestAngle(N,B); yaw=0; pitch=0; sYaw=0; sPitch=0; sVel.set(0,0,0);
-      walking=true;
-      if(!isTouch) window.walkMode?.startWalkMode(Q.camera, Q.renderer);
+      walking=false;
       mountHUD();
     } else {
       Q.controls && (Q.controls.enabled=true, Q.controls.update?.());

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -537,7 +537,7 @@
           }
         }
       }
-      function detectClusters(points, radius=1.2, threshold=5){
+      function detectClusters(points, radius=2.0, threshold=5){
         const clusters=[]; const visited=new Array(points.length).fill(false);
         for(let i=0;i<points.length;i++){
           if(visited[i]) continue; const group=[];
@@ -551,6 +551,21 @@
             clusters.push({center,radius,count:group.length,index:idx,t:points.length>1?idx/(points.length-1):0});
           }
         }
+        // ensure all path points are covered by at least one sphere
+        const covered=new Array(points.length).fill(false);
+        clusters.forEach(c=>{
+          for(let i=0;i<points.length;i++){
+            if(points[i].distanceTo(c.center)<=c.radius) covered[i]=true;
+          }
+        });
+        for(let i=0;i<points.length;i++){
+          if(!covered[i]){
+            const center=points[i].clone();
+            clusters.push({center,radius,count:1,index:i,t:points.length>1?i/(points.length-1):0});
+          }
+        }
+        // nudge centers apart so spheres don't overlap
+        ensureNoOverlap(clusters.map(c=>c.center), radius*2);
         return clusters;
       }
       function updateClusters(points){


### PR DESCRIPTION
## Summary
- Keep FPV camera locked to hash path without auto-switching to walking
- Generate non-overlapping cluster spheres and cover path entirely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2648b584c832aac1d734b461c783e