### PR TITLE
Smooth BTC hash navigation and gamepad speed control

### DIFF
--- a/frontend/fpv-explore.js
+++ b/frontend/fpv-explore.js
@@ -195,12 +195,15 @@ const THREE = window.THREE;
     const pads=navigator.getGamepads?Array.from(navigator.getGamepads()).filter(Boolean):[];
     if(!pads.length) return; const gp=pads[0], dz=0.12;
     const lx=gp.axes[0]||0, ly=gp.axes[1]||0, rx=gp.axes[2]||0, ry=gp.axes[3]||0;
-    inp.bank   = Math.abs(lx)>dz ? lx : 0;
-    inp.thrust = Math.abs(ly)>dz ? -ly : 0;
+    const rt=gp.buttons[7]?.value||0, lt=gp.buttons[6]?.value||0;
+    inp.bank = Math.abs(lx)>dz ? lx : 0;
+    let thrust = Math.abs(ly)>dz ? -ly : 0;
+    thrust += rt - lt;
+    inp.thrust = clamp(thrust,-1,1);
     yaw   -= (Math.abs(rx)>dz?rx:0)*0.03;
     pitch -= (Math.abs(ry)>dz?ry:0)*0.03*(cfg.invertY?-1:1);
     pitch = clamp(pitch,-1.0,1.0);
-    inp.run = (gp.buttons[4]?.pressed||gp.buttons[5]?.pressed)?1:0;
+    inp.run = rt>0.6?1:0;
     if (gp.buttons[2]?.pressed){ pathVisible=!pathVisible; if(tube) tube.visible=pathVisible; } // X
     if (gp.buttons[1]?.pressed) toggle(false); // B
   }

--- a/frontend/studio.html
+++ b/frontend/studio.html
@@ -121,6 +121,9 @@
       .ctrl input[type="range"]::-moz-range-track{ height:4px; background:rgba(10,132,255,.3); border-radius:2px; }
       .ctrl input[type="range"]::-moz-range-thumb{ width:18px; height:18px; border-radius:50%; background:var(--accent); cursor:pointer; }
 
+      /* highlight theme selector for visibility */
+      .theme-ctrl select{ border:2px solid var(--focus); }
+
       /* Dropzone */
       .dropzone{ position:relative; border:2px dashed var(--border); border-radius:14px; padding:14px; width:100%; min-height:84px; display:flex; align-items:center; justify-content:center; gap:10px; background:var(--soft); }
       .dropzone.drag{ border-color:var(--focus); box-shadow:0 0 0 4px var(--ring); }
@@ -242,10 +245,10 @@
             <label>Point Size</label>
             <input type="range" id="pointSize" min="0.005" max="0.5" step="0.005" value="0.02" />
           </div>
-          <div class="ctrl" title="Color mode for clouds/instances.">
+          <div class="ctrl theme-ctrl" title="Color mode for clouds/instances. Original theme reflects hash difficulty.">
             <label>Theme</label>
             <select id="theme">
-              <option value="original">Original</option>
+              <option value="original">Original (difficulty)</option>
               <option value="heatmap" selected>Heatmap (volatility)</option>
               <option value="lifecycle">Lifecycle (volume)</option>
             </select>
@@ -353,6 +356,7 @@
       const nfUSD = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
       const canvas = $('btc-hash-canvas');
       let renderer, scene, camera, controls, axes; let dotClouds = []; let hashLogEntries = []; let customGeometry = null;
+      let camVelocity = new THREE.Vector3();
       let clusterDev = false; let clusterInfoEl = null; let clusterMetricsVisible = false;
       const DPR_CAP = Math.min((window.devicePixelRatio||1), 1.8);
       let __targetDPR = Math.min(DPR_CAP, 1.4); // start moderate on mobile
@@ -587,7 +591,7 @@
         $('m-clusters').textContent = `Clusters — ${lastClusters.length}`;
       }
 
-      function applyClusterGravity(){
+      function applyClusterGravity(dt){
         if(!camera||!controls) return;
         const pos=camera.position;
         const pull=new THREE.Vector3();
@@ -604,8 +608,10 @@
             pull.add(toCenter.normalize().multiplyScalar(attractStrength));
           }
         });
-        camera.position.add(pull);
-        controls.target.add(pull);
+        camVelocity.add(pull.multiplyScalar(dt));
+        camVelocity.multiplyScalar(0.92); // damping
+        camera.position.add(camVelocity);
+        controls.target.add(camVelocity);
       }
 
       function clearClouds(){
@@ -923,7 +929,7 @@
           scene.rotation.y += 0.002;
           controls.autoRotate = true;
         }
-        applyClusterGravity();
+        applyClusterGravity(dt);
         if (camera) {
           const cp = $('camera-pos');
           if (cp) cp.textContent = `Pos: ${camera.position.x.toFixed(2)},${camera.position.y.toFixed(2)},${camera.position.z.toFixed(2)}`;


### PR DESCRIPTION
## Summary
- Add velocity-based gravity for smoother camera navigation between BTC hash clusters
- Highlight theme selector and note original theme shows hash difficulty
- Map Xbox triggers to control speed and reverse in explore mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3012f99f8832aa34a0f6791e1fcb6